### PR TITLE
Fix userdev launch handler looking for file with wrong version

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/StringSubstitutor.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/StringSubstitutor.java
@@ -17,7 +17,7 @@ public class StringSubstitutor
 {
     private static final Map<String,String> globals = ImmutableMap.of(
             "mcVersion", FMLLoader.versionInfo().mcVersion(),
-            "forgeVersion", FMLLoader.versionInfo().fmlVersion()
+            "forgeVersion", FMLLoader.versionInfo().forgeVersion()
     );
 
     public static String replace(final String in, final ModFile file) {

--- a/loader/src/main/java/net/minecraftforge/fml/loading/targets/ForgeUserdevLaunchHandler.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/targets/ForgeUserdevLaunchHandler.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
 public abstract class ForgeUserdevLaunchHandler extends CommonUserdevLaunchHandler {
     @Override
     protected void processStreams(String[] classpath, VersionInfo versionInfo, Stream.Builder<Path> mc, Stream.Builder<List<Path>> mods) {
-        var forge = findJarOnClasspath(classpath, "forge-" + versionInfo.mcAndFmlVersion());
+        var forge = findJarOnClasspath(classpath, "forge-" + versionInfo.mcAndForgeVersion());
         mc.add(forge);
     }
 }


### PR DESCRIPTION
It seems in https://github.com/pupnewfster/FancyModLoader/commit/c82cfc465078d6abccd77a591a13f99e344e4b18 a few paths version checks got broken and started checking the fml version instead of the forge version. The majority of the incorrect checks got corrected in https://github.com/neoforged/FancyModLoader/commit/9b4f99ae7afa857d741aa3efd96e626f1c9ff7c7 but one was missed in the userdev launch handler leading to userdev failing to be able to find forge.

Edit: This PR also fixes the version set in the globals for the forge version so that forge reports the proper version when viewed in the mod list or when the modinfo is queried directly.