### PR TITLE
Fix use of OS-dependent `File.separatorChar` in `FileUtils`

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/FileUtils.java
@@ -5,7 +5,6 @@
 
 package net.minecraftforge.fml.loading;
 
-import java.io.File;
 import java.nio.file.Path;
 
 public class FileUtils
@@ -23,7 +22,7 @@ public class FileUtils
 
     public static boolean matchFileName(String path, boolean exact, String... matches) {
         // Extract file name from path
-        String name = path.substring(Math.min(path.lastIndexOf(File.separatorChar) + 1, path.length()));
+        String name = Path.of(path).getFileName().toString();
         // Check if it contains any of the desired keywords
         for (String match : matches) {
             if (exact ? name.equals(match) : name.contains(match)) {


### PR DESCRIPTION
This PR removes the use of the OS-dependent `File.separatorChar` in `FileUtils`, and substituting it with the use of the JDK's `Path` interface (which properly recognizes both separator slashes, even when mixed).  

This PR blocks the merge of neoforged/NeoForge#68, which in turn blocks the resolution of neoforged/NeoForge#38. See https://github.com/neoforged/NeoForge/pull/68#issuecomment-1662480101 for more details on what this resolves.