### PR TITLE
Allow mod constructors to receive useful arguments

### DIFF
--- a/languages/java/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/languages/java/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -76,7 +76,8 @@ public class FMLModContainer extends ModContainer
                 // Otherwise look for constructor that can accept more arguments
                 Map<Class<?>, Object> allowedConstructorArgs = Map.of(
                         IEventBus.class, eventBus,
-                        ModContainer.class, this);
+                        ModContainer.class, this,
+                        FMLModContainer.class, this);
 
                 constructorsLoop: for (var constructor : modClass.getDeclaredConstructors()) {
                     var parameterTypes = constructor.getParameterTypes();

--- a/languages/java/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/languages/java/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -21,7 +21,11 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class FMLModContainer extends ModContainer
 {
@@ -65,7 +69,44 @@ public class FMLModContainer extends ModContainer
         try
         {
             LOGGER.trace(LOADING, "Loading mod instance {} of type {}", getModId(), modClass.getName());
-            this.modInstance = modClass.getDeclaredConstructor().newInstance();
+            try {
+                // Try noargs constructor first
+                this.modInstance = modClass.getDeclaredConstructor().newInstance();
+            } catch (NoSuchMethodException ignored) {
+                // Otherwise look for constructor that can accept more arguments
+                Map<Class<?>, Object> allowedConstructorArgs = Map.of(
+                        IEventBus.class, eventBus,
+                        ModContainer.class, this);
+
+                constructorsLoop: for (var constructor : modClass.getDeclaredConstructors()) {
+                    var parameterTypes = constructor.getParameterTypes();
+                    Object[] constructorArgs = new Object[parameterTypes.length];
+                    Set<Class<?>> foundArgs = new HashSet<>();
+
+                    for (int i = 0; i < parameterTypes.length; i++) {
+                        Object argInstance = allowedConstructorArgs.get(parameterTypes[i]);
+                        if (argInstance == null) {
+                            // Unknown argument, try next constructor method...
+                            continue constructorsLoop;
+                        }
+
+                        if (foundArgs.contains(parameterTypes[i])) {
+                            throw new RuntimeException("Duplicate constructor argument type: " + parameterTypes[i]);
+                        }
+
+                        foundArgs.add(parameterTypes[i]);
+                        constructorArgs[i] = argInstance;
+                    }
+
+                    // All arguments are found
+                    this.modInstance = constructor.newInstance(constructorArgs);
+                }
+
+                if (this.modInstance == null) {
+                    throw new RuntimeException("Could not find mod constructor. Allowed optional argument classes: " +
+                            allowedConstructorArgs.keySet().stream().map(Class::getSimpleName).collect(Collectors.joining(", ")));
+                }
+            }
             LOGGER.trace(LOADING, "Loaded mod instance {} of type {}", getModId(), modClass.getName());
         }
         catch (Throwable e)


### PR DESCRIPTION
This allows mod to optionally receive their mod bus and mod container via constructor arguments.

As a next step, I imagine methods like `registerConfig` and `registerExtensionPoint` will be moved from `ModLoadingContext` to `ModContainer`.

Tested by publishing to maven local and loading it in forgedev. The errors also work as expected:
![image](https://github.com/neoforged/FancyModLoader/assets/13494793/503218d9-1bef-4230-8722-3d15593d76c4)
![image](https://github.com/neoforged/FancyModLoader/assets/13494793/c7f45cc3-ec8b-435b-812e-fdabd156b2c4)
