### PR TITLE
Correctly support EventPriority for non-parallel mod bus events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ allprojects {
     version = gradleutils.getTagOffsetVersion()
 
     repositories {
+        mavenLocal()
         mavenCentral()
 
         maven {

--- a/core/src/main/java/net/minecraftforge/fml/ModContainer.java
+++ b/core/src/main/java/net/minecraftforge/fml/ModContainer.java
@@ -6,6 +6,7 @@
 package net.minecraftforge.fml;
 
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.fml.config.IConfigEvent;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.IModBusEvent;
@@ -171,4 +172,11 @@ public abstract class ModContainer
      * @param e Event to accept
      */
     protected <T extends Event & IModBusEvent> void acceptEvent(T e) {}
+
+    /**
+     * Accept an arbitrary event for processing by the mod, only for a specific phase.
+     * Probably posted to an event bus in the lower level container.
+     * @param e Event to accept
+     */
+    protected <T extends Event & IModBusEvent> void acceptEvent(EventPriority phase, T e) {}
 }

--- a/languages/java/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
+++ b/languages/java/src/main/java/net/minecraftforge/fml/javafmlmod/FMLModContainer.java
@@ -8,6 +8,7 @@ package net.minecraftforge.fml.javafmlmod;
 import net.minecraftforge.eventbus.EventBusErrorMessage;
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.IEventListener;
 import net.minecraftforge.fml.ModContainer;
@@ -108,6 +109,18 @@ public class FMLModContainer extends ModContainer
             LOGGER.trace(LOADING, "Fired event for modid {} : {}", this.getModId(), e);
         } catch (Throwable t) {
             LOGGER.error(LOADING,"Caught exception during event {} dispatch for modid {}", e, this.getModId(), t);
+            throw new ModLoadingException(modInfo, modLoadingStage, "fml.modloading.errorduringevent", t);
+        }
+    }
+
+    @Override
+    protected <T extends Event & IModBusEvent> void acceptEvent(EventPriority phase, final T e) {
+        try {
+            LOGGER.trace(LOADING, "Firing event for modid {} : {} (event phase {})", this.getModId(), e, phase);
+            this.eventBus.postPhase(phase, e);
+            LOGGER.trace(LOADING, "Fired event for modid {} : {} (event phase {})", this.getModId(), e, phase);
+        } catch (Throwable t) {
+            LOGGER.error(LOADING,"Caught exception during event {} dispatch for modid {} (event phase {})", e, this.getModId(), phase, t);
             throw new ModLoadingException(modInfo, modLoadingStage, "fml.modloading.errorduringevent", t);
         }
     }

--- a/languages/lowcode/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
+++ b/languages/lowcode/src/main/java/net/minecraftforge/fml/lowcodemod/LowCodeModContainer.java
@@ -6,15 +6,11 @@
 package net.minecraftforge.fml.lowcodemod;
 
 import com.mojang.logging.LogUtils;
-import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.fml.IExtensionPoint;
 import net.minecraftforge.fml.ModContainer;
-import net.minecraftforge.fml.event.IModBusEvent;
 import net.minecraftforge.forgespi.language.IModInfo;
 import net.minecraftforge.forgespi.language.ModFileScanData;
 import org.slf4j.Logger;
-
-import java.util.Objects;
 
 import static net.minecraftforge.fml.loading.LogMarkers.LOADING;
 
@@ -44,10 +40,5 @@ public class LowCodeModContainer extends ModContainer
     public Object getMod()
     {
         return modInstance;
-    }
-
-    @Override
-    protected <T extends Event & IModBusEvent> void acceptEvent(final T e)
-    {
     }
 }


### PR DESCRIPTION
Depends on neoforged/Bus#12.

Needs proper testing, which I haven't done yet.

Note that this is a breaking change, so we have to wait until 1.20.2.