### PR TITLE
Fix 100% CPU usage on one core when SyncExecutor is waiting for tasks

### DIFF
--- a/core/src/main/java/net/minecraftforge/fml/ModWorkManager.java
+++ b/core/src/main/java/net/minecraftforge/fml/ModWorkManager.java
@@ -22,12 +22,15 @@ public class ModWorkManager {
         boolean driveOne();
 
         default void drive(Runnable ticker) {
+            boolean ranOne = false;
             if (!selfDriven()) {
                 ticker.run();
                 while (true) {
                     if (!driveOne()) break;
+                    ranOne = true;
                 }
-            } else {
+            }
+            if(!ranOne) {
                 // park for a bit so other threads can schedule
                 LockSupport.parkNanos(PARK_TIME);
             }


### PR DESCRIPTION
The change in this PR aims to address a fairly major scheduling issue with the FML work queue. If the main thread is not given work to do, `DrivenExecutor#drive` busy-waits on the work queue until a task is added. This is very wasteful of a CPU core, and might contribute to slower launch times during the parallel stages of launch. I have been hacking around this in ModernFix for some time but would like to take the opportunity to get it fixed properly.

The issue is that `drive` is called in a tight loop from `waitForTransition`. The simplest fix is to run the existing parking logic in `drive` if it didn't execute at least one task. This does not break any interactions with the early loading window as we do not block forever, but it alleviates the original issue of spinning endlessly.

An alternative option would be to return a boolean from `drive` and handle the parking inside `waitForTransition` instead.

Here is a screenshot of the original behavior. The `glfwPollEvents` function is not blocking, and in any case looking at the system process viewer demonstrates very high CPU usage given that nothing is happening except rendering the splash screen.

![cpu_usage_before](https://github.com/neoforged/FancyModLoader/assets/42941056/a8d8b6ab-c863-4725-8a6f-b50b5527209c)

Here is a screenshot of the new behavior. CPU usage in the process viewer is now very low, and the profiler reflects this.

![cpu_usage_after](https://github.com/neoforged/FancyModLoader/assets/42941056/7e992d18-2e83-4e3b-9016-38f7997cf05d)

This change was tested by pointing a NeoForge workspace at the modified FancyModLoader version and adding the following to the end of the `ForgeMod` constructor.

```java
        // Stall worker thread forever, to emulate long-running mod constructors that don't enqueue anything
        while(true) {
            LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(10));
        }
```