### PR TITLE
Add ASM flags to skip code and some debug info in background scan handler

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/BackgroundScanHandler.java
@@ -44,6 +44,7 @@ public class BackgroundScanHandler
         modContentScanner = Executors.newSingleThreadExecutor(r -> {
             final Thread thread = Executors.defaultThreadFactory().newThread(r);
             thread.setDaemon(true);
+            thread.setName("Background Scan Handler");
             return thread;
         });
         scannedFiles = new ArrayList<>();

--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
@@ -45,7 +45,7 @@ public class Scanner {
         try (InputStream in = Files.newInputStream(path)){
             ModClassVisitor mcv = new ModClassVisitor();
             ClassReader cr = new ClassReader(in);
-            cr.accept(mcv, 0);
+            cr.accept(mcv, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
             mcv.buildData(result.getClasses(), result.getAnnotations());
         } catch (IOException | IllegalArgumentException e) {
             // mark path bad


### PR DESCRIPTION
The background scan handler looked like this before on the FC pack:
![image](https://github.com/neoforged/FancyModLoader/assets/13494793/00ec8790-e5c7-48dc-b66e-43748cff6d9a)
We can skip `readCode` entirely with these flags.

Performance numbers for mod scanning for the FC pack:
```
Baseline: 22s
With ASM flags: 15s
```

Still far from ideal, but it runs in parallel with vanilla bootstrap so vanilla boostrap is now the bottleneck in my tests (likely due to many class transforms, gonna look into that).