### PR TITLE
Explicitly pass null filter when creating SecureJar/UnionFS

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractModProvider.java
@@ -38,7 +38,7 @@ public abstract class AbstractModProvider implements IModProvider
         var sj = SecureJar.from(
                 Manifest::new,
                 jar -> jar.moduleDataProvider().findFile(MODS_TOML).isPresent() ? mjm : JarMetadata.from(jar, path),
-                (root, p) -> true,
+                null,
                 path
         );
 

--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
@@ -34,7 +34,7 @@ public class ExplodedDirectoryLocator implements IModLocator {
         explodedMods.forEach(explodedMod ->
                 ModJarMetadata.buildFile(this,
                         jar->jar.moduleDataProvider().findFile("/META-INF/mods.toml").isPresent(),
-                        (a,b) -> true,
+                        null,
                         explodedMod.paths().toArray(Path[]::new))
                 .ifPresentOrElse(f->mods.put(explodedMod, f), () -> LOGGER.warn(LogMarkers.LOADING, "Failed to find exploded resource mods.toml in directory {}", explodedMod.paths().get(0).toString())));
         return mods.values().stream().map(mf->new IModLocator.ModFileOrException(mf, null)).toList();

--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModJarMetadata.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModJarMetadata.java
@@ -31,7 +31,7 @@ public final class ModJarMetadata implements JarMetadata {
     // TODO: Remove helper functions to cleanup api
     @Deprecated(forRemoval = true, since="1.18")
     static IModFile buildFile(IModLocator locator, Path... files) {
-        return buildFile(locator, j->true, (a,b) -> true, files).orElseThrow(()->new IllegalArgumentException("Failed to find valid JAR file"));
+        return buildFile(locator, j->true, null, files).orElseThrow(()->new IllegalArgumentException("Failed to find valid JAR file"));
     }
 
     // TODO: Remove helper functions to cleanup api

--- a/loader/src/main/java/net/minecraftforge/fml/loading/targets/CommonClientLaunchHandler.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/targets/CommonClientLaunchHandler.java
@@ -34,7 +34,7 @@ public abstract class CommonClientLaunchHandler extends CommonLaunchHandler {
 
         processMCStream(vers, mcstream, modstream);
 
-        return new LocatedPaths(mcstream.build().toList(), (a,b) -> true, modstream.build().toList(), this.getFmlPaths(this.getLegacyClasspath()));
+        return new LocatedPaths(mcstream.build().toList(), null, modstream.build().toList(), this.getFmlPaths(this.getLegacyClasspath()));
     }
 
     protected abstract void processMCStream(VersionInfo versionInfo, Stream.Builder<Path> mc, Stream.Builder<List<Path>> mods);

--- a/loader/src/main/java/net/minecraftforge/fml/loading/targets/CommonServerLaunchHandler.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/targets/CommonServerLaunchHandler.java
@@ -39,11 +39,17 @@ public abstract class CommonServerLaunchHandler extends CommonLaunchHandler {
             }, mcextra
         );
         BiPredicate<String, String> filter = (path, base) -> true;
+        BiPredicate<String, String> nullFilter = filter;
 
         var mcstream = Stream.<Path>builder().add(mc).add(mcextra_filtered.getRootPath());
         var modstream = Stream.<List<Path>>builder();
 
         filter = processMCStream(vers, mcstream, filter, modstream);
+
+        // use this hack instead of setting filter to null initially for backwards compatibility if anything overrides
+        // processMCStream with a custom filter
+        if (filter == nullFilter)
+            filter = null;
 
         return new LocatedPaths(mcstream.build().toList(), filter, modstream.build().toList(), this.getFmlPaths(this.getLegacyClasspath()));
     }


### PR DESCRIPTION
`UnionFileSystem.testFilter` contains an optimization intended for the case where no path filter is set:

https://github.com/McModLauncher/securejarhandler/blob/1dedb0655d9f4b8cf310ea7095b38c7a978a42ab/src/main/java/cpw/mods/niofs/union/UnionFileSystem.java#L397

However, all of the code paths creating commonly-used UnionFS instances in FML are passing non-null `(a, b) -> true` lambdas, defeating this optimization. I have frequently seen `testFilter` appearing as a hotspot in my profiling while working on ModernFix.

The solution is quite simple: start passing `null` instead of a lambda. I've gone through the codebase and replaced all the lambdas matching this pattern.

Would appreciate review from someone familiar with this part of the codebase.
