### PR TITLE
Require side to be declared in mods.toml

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -38,6 +38,7 @@ public class ModInfo implements IModInfo, IConfigurable
     private final ArtifactVersion version;
     private final String displayName;
     private final String description;
+    private final DependencySide side;
     private final Optional<String> logoFile;
     private final boolean logoBlur;
     private final Optional<URL> updateJSONURL;
@@ -81,6 +82,9 @@ public class ModInfo implements IModInfo, IConfigurable
                 .orElse(this.modId);
         this.description = config.<String>getConfigElement("description")
                 .orElse("MISSING DESCRIPTION");
+        this.side = config.<String>getConfigElement("side")
+                .map(DependencySide::valueOf)
+                .orElseThrow(() -> new InvalidModFileException("Missing side", owningFile));
         this.logoFile = Optional.ofNullable(config.<String>getConfigElement("logoFile")
                 .orElseGet(() -> ownFile.flatMap(mf -> mf.<String>getConfigElement("logoFile"))
                         .orElse(null)));
@@ -128,6 +132,11 @@ public class ModInfo implements IModInfo, IConfigurable
         return this.description;
     }
 
+    @Override
+    public DependencySide getSide()
+    {
+        return this.side;
+    }
     @Override
     public ArtifactVersion getVersion() {
         return version;


### PR DESCRIPTION
After some discussion in the [discord](https://discord.com/channels/313125603924639766/313125603924639766/1157126571807752252) about how easy it is for users to drop a server side on the client and crash the server. To make the crash less opaque I propose we require modders to declare the side their mod is on during construction.

For this PR to work this [patch](https://github.com/neoforged/NeoForgeSPI/pull/2) for NeoForgeSPI needs to be merged

Some additional things for discussion for another PR, I do think we can do a better job collecting and displaying info to the end user server side there's some UX work that could be done.