### PR TITLE
Normalize CRLF mod description line endings to use LF instead

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModInfo.java
@@ -80,6 +80,8 @@ public class ModInfo implements IModInfo, IConfigurable
         this.displayName = config.<String>getConfigElement("displayName")
                 .orElse(this.modId);
         this.description = config.<String>getConfigElement("description")
+                // Normalize CRLF line endings to use LF instead
+                .map(desc -> desc.replace("\r\n", "\n"))
                 .orElse("MISSING DESCRIPTION");
         this.logoFile = Optional.ofNullable(config.<String>getConfigElement("logoFile")
                 .orElseGet(() -> ownFile.flatMap(mf -> mf.<String>getConfigElement("logoFile"))


### PR DESCRIPTION
### The issue

Minecraft can't properly display CRLF line endings in its GUIs. This leads to them being shown as characters in mod descriptions on the NeoForge mod list screen, as described in the following issue

- neoforged/NeoForge#104

#### Expected behavior

Line ending characters should not be visible by any means.
 
### The solution

When parsing mod descriptions, we replace all CRLF line endings with LF. By eliminating the root cause of this issue in FML, we ensure CRLFs will not show up anywhere in game, be it the neoforge mod list screen or other mod GUIs.

Fixes neoforged/NeoForge#104

| Before | After |
|--------|--------|
| ![broken crlf](https://github.com/neoforged/FancyModLoader/assets/51261569/208d454e-edd5-4f3c-aec7-de0651c66bfd)| ![fancy lf](https://github.com/neoforged/FancyModLoader/assets/51261569/167ca72e-41b1-4798-8414-e7df99794d22)| 

