### PR TITLE
Run annotation scanner in parallel across different mods

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFile.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFile.java
@@ -56,7 +56,7 @@ public class ModFile implements IModFile {
     private final IModProvider provider;
     private       IModFileInfo modFileInfo;
     private ModFileScanData fileModFileScanData;
-    private CompletableFuture<ModFileScanData> futureScanResult;
+    private volatile CompletableFuture<ModFileScanData> futureScanResult;
     private List<CoreModFile> coreMods;
     private List<String> mixinConfigs;
     private Path accessTransformer;
@@ -158,11 +158,11 @@ public class ModFile implements IModFile {
     }
 
     public void setScanResult(final ModFileScanData modFileScanData, final Throwable throwable) {
-        this.futureScanResult = null;
         this.fileModFileScanData = modFileScanData;
         if (throwable != null) {
             this.scanError = throwable;
         }
+        this.futureScanResult = null;
     }
 
     public void setFileProperties(Map<String, Object> fileProperties) {


### PR DESCRIPTION
The annotation scan runs in parallel with Minecraft's bootstrap, but in large mod packs there's a chance that it could take longer than bootstrap. However it is trivially parallelizable.