### PR TITLE
Don't turn off VSync when rendering from Minecraft context

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -265,7 +265,6 @@ public class DisplayWindow implements ImmediateWindowProvider {
     public void render(int alpha) {
         var currentVAO = glGetInteger(GL_VERTEX_ARRAY_BINDING);
         var currentFB = glGetInteger(GL_READ_FRAMEBUFFER_BINDING);
-        glfwSwapInterval(0);
         glViewport(0, 0, this.context.scaledWidth(), this.context.scaledHeight());
         RenderElement.globalAlpha = alpha;
         framebuffer.activate();


### PR DESCRIPTION
The early loading screen currently disables VSync by force whenever the `DisplayWindow#render` method is called; since Minecraft only enables it once during startup, this causes the VSync option to not work in game until it's toggled off and on again.

There doesn't seem to be a good reason to disable this again after already disabling it in `setupMinecraftWindow`, so the call can just be removed.