### PR TITLE
Wait for window initialization to complete in setupMinecraftWindow

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -40,11 +40,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -86,6 +82,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
     private int framecount;
     private EarlyFramebuffer framebuffer;
     private ScheduledFuture<?> windowTick;
+    private ScheduledFuture<?> initializationFuture;
 
     private PerformanceInfo performanceInfo;
     private ScheduledFuture<?> performanceTick;
@@ -288,7 +285,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
             return thread;
         });
         initWindow(mcVersion);
-        renderScheduler.schedule(() -> initRender(mcVersion, forgeVersion), 1, TimeUnit.MILLISECONDS);
+        this.initializationFuture = renderScheduler.schedule(() -> initRender(mcVersion, forgeVersion), 1, TimeUnit.MILLISECONDS);
         return this::periodicTick;
     }
 
@@ -519,6 +516,12 @@ public class DisplayWindow implements ImmediateWindowProvider {
      * @return the Window we own.
      */
     public long setupMinecraftWindow(final IntSupplier width, final IntSupplier height, final Supplier<String> title, final LongSupplier monitorSupplier) {
+        // wait for the window to actually be initialized
+        try {
+            this.initializationFuture.get();
+        } catch(InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
         // we have to spin wait for the window ticker
         ImmediateWindowHandler.updateProgress("Initializing Game Graphics");
         while (!this.windowTick.isDone()) {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -518,9 +518,12 @@ public class DisplayWindow implements ImmediateWindowProvider {
     public long setupMinecraftWindow(final IntSupplier width, final IntSupplier height, final Supplier<String> title, final LongSupplier monitorSupplier) {
         // wait for the window to actually be initialized
         try {
-            this.initializationFuture.get();
+            this.initializationFuture.get(30, TimeUnit.SECONDS);
         } catch(InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
+        } catch(TimeoutException e) {
+            Thread.dumpStack();
+            crashElegantly("We seem to be having trouble initializing the window, waited for 30 seconds");
         }
         // we have to spin wait for the window ticker
         ImmediateWindowHandler.updateProgress("Initializing Game Graphics");


### PR DESCRIPTION
This should fix the crash reported in https://github.com/MinecraftForge/MinecraftForge/issues/9673. I suspect the GL context takes a long time to initialize, and so `setupMinecraftWindow` gets called before `initRender` actually returns. Blocking on the future returned by the scheduler should resolve this.

I accidentally pushed this to a branch on the upstream repo instead of my fork, sorry about that.