### PR TITLE
Reintroduce ModConfig#getHandler

### DIFF
--- a/core/src/main/java/net/neoforged/fml/config/ConfigTracker.java
+++ b/core/src/main/java/net/neoforged/fml/config/ConfigTracker.java
@@ -57,7 +57,7 @@ public class ConfigTracker {
 
     private void openConfig(final ModConfig config, final Path configBasePath) {
         LOGGER.trace(CONFIG, "Loading config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
-        final CommentedFileConfig configData = ConfigFileTypeHandler.TOML.reader(configBasePath).apply(config);
+        final CommentedFileConfig configData = config.getHandler().reader(configBasePath).apply(config);
         config.setConfigData(configData);
         IConfigEvent.loading(config).post();
         config.save();
@@ -67,7 +67,7 @@ public class ConfigTracker {
         if (config.getConfigData() != null) {
             LOGGER.trace(CONFIG, "Closing config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
             // stop the filewatcher before we save the file and close it, so reload doesn't fire
-            ConfigFileTypeHandler.TOML.unload(configBasePath, config);
+            config.getHandler().unload(configBasePath, config);
             var unloading = IConfigEvent.unloading(config);
             if (unloading != null)
                 unloading.post();

--- a/core/src/main/java/net/neoforged/fml/config/ModConfig.java
+++ b/core/src/main/java/net/neoforged/fml/config/ModConfig.java
@@ -48,6 +48,10 @@ public class ModConfig
         return fileName;
     }
 
+    public ConfigFileTypeHandler getHandler() {
+        return ConfigFileTypeHandler.TOML;
+    }
+
     @SuppressWarnings("unchecked")
     public <T extends IConfigSpec<T>> IConfigSpec<T> getSpec() {
         return (IConfigSpec<T>) spec;


### PR DESCRIPTION
Adds back the `ModConfig#getHandler` method that was removed in #40 so that mods can actually override the type handler.