### PR TITLE
Deprecate `FMLJavaModLoadingContext` for removal

### DIFF
--- a/languages/java/src/main/java/net/neoforged/fml/common/Mod.java
+++ b/languages/java/src/main/java/net/neoforged/fml/common/Mod.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.Bindings;
+import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.javafmlmod.FMLJavaModLoadingContext;
 
 /**
@@ -76,7 +77,7 @@ public @interface Mod
             FORGE(Bindings.getForgeBus()),
             /**
              * The mod specific Event bus.
-             * @see FMLJavaModLoadingContext#getModEventBus()
+             * @see ModContainer#getEventBus()
              */
             MOD(()-> FMLJavaModLoadingContext.get().getModEventBus());
 
@@ -86,6 +87,7 @@ public @interface Mod
                 this.busSupplier = eventBusSupplier;
             }
 
+            @Deprecated(forRemoval = true)
             public Supplier<IEventBus> bus() {
                 return busSupplier;
             }

--- a/languages/java/src/main/java/net/neoforged/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/languages/java/src/main/java/net/neoforged/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -6,6 +6,8 @@
 package net.neoforged.fml.javafmlmod;
 
 import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.Bindings;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.neoforgespi.language.ModFileScanData;
@@ -57,8 +59,16 @@ public class AutomaticEventSubscriber
             if (Objects.equals(mod.getModId(), modId) && sides.contains(FMLEnvironment.dist)) {
                 try
                 {
-                    LOGGER.debug(LOADING, "Auto-subscribing {} to {}", ad.clazz().getClassName(), busTarget);
-                    busTarget.bus().get().register(Class.forName(ad.clazz().getClassName(), true, loader));
+                    IEventBus bus = switch (busTarget) {
+                        case FORGE -> Bindings.getForgeBus().get();
+                        case MOD -> mod.getEventBus();
+                    };
+
+                    if (bus != null) {
+                        LOGGER.debug(LOADING, "Auto-subscribing {} to {}", ad.clazz().getClassName(), busTarget);
+
+                        bus.register(Class.forName(ad.clazz().getClassName(), true, loader));
+                    }
                 }
                 catch (ClassNotFoundException e)
                 {

--- a/languages/java/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLoadingContext.java
+++ b/languages/java/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLoadingContext.java
@@ -8,6 +8,7 @@ package net.neoforged.fml.javafmlmod;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModLoadingContext;
 
+@Deprecated(forRemoval = true)
 public class FMLJavaModLoadingContext
 {
     private final FMLModContainer container;
@@ -17,6 +18,7 @@ public class FMLJavaModLoadingContext
     }
 
     /**
+     * @deprecated You can directly receive the event bus as a mod constructor argument.
      * @return The mod's event bus, to allow subscription to Mod specific events
      */
     public IEventBus getModEventBus()


### PR DESCRIPTION
As requested.

How do we handle this after `getModEventBus` got removed?
- https://github.com/neoforged/FancyModLoader/blob/main/languages/java/src/main/java/net/neoforged/fml/common/Mod.java#L81

What about updating other javadocs that have this method?