### PR TITLE
Allow loading configs from a specified override path

### DIFF
--- a/core/src/main/java/net/neoforged/fml/config/ConfigFileTypeHandler.java
+++ b/core/src/main/java/net/neoforged/fml/config/ConfigFileTypeHandler.java
@@ -73,10 +73,10 @@ public class ConfigFileTypeHandler {
         };
     }
 
-    public void unload(Path configBasePath, ModConfig config) {
+    public void unload(ModConfig config) {
         if (FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.DISABLE_CONFIG_WATCHER))
             return;
-        Path configPath = configBasePath.resolve(config.getFileName());
+        Path configPath = config.getFullPath();
         try {
             FileWatcher.defaultInstance().removeWatch(configPath);
         } catch (RuntimeException e) {


### PR DESCRIPTION
Use case is to switch NeoForge server configs from being in the `serverconfig` folder by default to being generated in the `config` folder, but allowing them to be copy pasted to the `serverconfig` folder in the cases users want to have per save overrides for certain values.

This PR also simplifies the logic for removing the file watch so that we don't have to determine which location we initially loaded the file from.