### PR TITLE
Only crash if mods found by the MC locator (i.e. dev mods) are using the `mandatory` field

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -203,8 +203,6 @@ public class ModInfo implements IModInfo, IConfigurable
     }
 
     class ModVersion implements net.neoforged.neoforgespi.language.IModInfo.ModVersion {
-        public static final boolean MANDATORY_DEPRECATION_CRASH = !Boolean.parseBoolean(System.getProperty("fml.disableDependencyMandatoryDeprecation", "false"));
-
         private IModInfo owner;
         private final String modId;
         private final VersionRange versionRange;
@@ -224,7 +222,7 @@ public class ModInfo implements IModInfo, IConfigurable
                         if (mandatory.isPresent()) {
                             if (!FMLLoader.isProduction()) {
                                 LOGGER.error("Mod '{}' uses deprecated 'mandatory' field in the dependency declaration for '{}'. Use the 'type' field and 'required'/'optional' instead", owner.getModId(), modId);
-                                if (MANDATORY_DEPRECATION_CRASH) {
+                                if (owner.getOwningFile().getFile().getProvider() instanceof ExplodedDirectoryLocator) {
                                     throw new InvalidModFileException("Deprecated 'mandatory' field is used in dependency", getOwningFile());
                                 }
                             }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -217,11 +217,13 @@ public class ModInfo implements IModInfo, IConfigurable
             this.modId = config.<String>getConfigElement("modId")
                     .orElseThrow(()->new InvalidModFileException("Missing required field modid in dependency", getOwningFile()));
             this.type = config.<String>getConfigElement("type")
+                    // TODO - 1.21: remove the fallback to the mandatory field
                     .map(str -> str.toUpperCase(Locale.ROOT)).map(DependencyType::valueOf).orElseGet(() -> {
                         final var mandatory = config.<Boolean>getConfigElement("mandatory");
                         if (mandatory.isPresent()) {
                             if (!FMLLoader.isProduction()) {
                                 LOGGER.error("Mod '{}' uses deprecated 'mandatory' field in the dependency declaration for '{}'. Use the 'type' field and 'required'/'optional' instead", owner.getModId(), modId);
+                                // only error the mod being "developed" (i.e. found through the MOD_CLASSES) to prevent dependencies from causing the crash
                                 if (owner.getOwningFile().getFile().getProvider() instanceof ExplodedDirectoryLocator) {
                                     throw new InvalidModFileException("Deprecated 'mandatory' field is used in dependency", getOwningFile());
                                 }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -203,7 +203,7 @@ public class ModInfo implements IModInfo, IConfigurable
     }
 
     class ModVersion implements net.neoforged.neoforgespi.language.IModInfo.ModVersion {
-        public static final boolean DISABLE_MANDATORY_DEPRECATION = !Boolean.parseBoolean(System.getProperty("fml.disableDependencyMandatoryDeprecation", "false"));
+        public static final boolean MANDATORY_DEPRECATION_CRASH = !Boolean.parseBoolean(System.getProperty("fml.disableDependencyMandatoryDeprecation", "false"));
 
         private IModInfo owner;
         private final String modId;
@@ -224,7 +224,7 @@ public class ModInfo implements IModInfo, IConfigurable
                         if (mandatory.isPresent()) {
                             if (!FMLLoader.isProduction()) {
                                 LOGGER.error("Mod '{}' uses deprecated 'mandatory' field in the dependency declaration for '{}'. Use the 'type' field and 'required'/'optional' instead", owner.getModId(), modId);
-                                if (!DISABLE_MANDATORY_DEPRECATION) {
+                                if (MANDATORY_DEPRECATION_CRASH) {
                                     throw new InvalidModFileException("Deprecated 'mandatory' field is used in dependency", getOwningFile());
                                 }
                             }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -224,7 +224,7 @@ public class ModInfo implements IModInfo, IConfigurable
                             if (!FMLLoader.isProduction()) {
                                 LOGGER.error("Mod '{}' uses deprecated 'mandatory' field in the dependency declaration for '{}'. Use the 'type' field and 'required'/'optional' instead", owner.getModId(), modId);
                                 // only error the mod being "developed" (i.e. found through the MOD_CLASSES) to prevent dependencies from causing the crash
-                                if (owner.getOwningFile().getFile().getProvider() instanceof ExplodedDirectoryLocator) {
+                                if (owner.getOwningFile().getFile().getProvider() instanceof MinecraftLocator) {
                                     throw new InvalidModFileException("Deprecated 'mandatory' field is used in dependency", getOwningFile());
                                 }
                             }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -203,6 +203,8 @@ public class ModInfo implements IModInfo, IConfigurable
     }
 
     class ModVersion implements net.neoforged.neoforgespi.language.IModInfo.ModVersion {
+        public static final boolean DISABLE_MANDATORY_DEPRECATION = !Boolean.parseBoolean(System.getProperty("fml.disableDependencyMandatoryDeprecation", "false"));
+
         private IModInfo owner;
         private final String modId;
         private final VersionRange versionRange;
@@ -222,7 +224,9 @@ public class ModInfo implements IModInfo, IConfigurable
                         if (mandatory.isPresent()) {
                             if (!FMLLoader.isProduction()) {
                                 LOGGER.error("Mod '{}' uses deprecated 'mandatory' field in the dependency declaration for '{}'. Use the 'type' field and 'required'/'optional' instead", owner.getModId(), modId);
-                                throw new InvalidModFileException("Deprecated 'mandatory' field is used in dependency", getOwningFile());
+                                if (!DISABLE_MANDATORY_DEPRECATION) {
+                                    throw new InvalidModFileException("Deprecated 'mandatory' field is used in dependency", getOwningFile());
+                                }
                             }
 
                             return mandatory.get() ? DependencyType.REQUIRED : DependencyType.OPTIONAL;


### PR DESCRIPTION
This PR makes the mod info parser only crash in-dev if mods found by the MC locator (i.e. dev mods) are using the `mandatory` field instead of the `type` one, preventing dependencies from causing the error.

Fixes [not really, Neo bump required] https://github.com/neoforged/NeoForge/issues/407