### PR TITLE
Remove hard casts to `ModFile` and co

### DIFF
--- a/core/src/main/java/net/neoforged/fml/ModList.java
+++ b/core/src/main/java/net/neoforged/fml/ModList.java
@@ -51,21 +51,20 @@ public class ModList
     private static ModList INSTANCE;
     private final List<IModFileInfo> modFiles;
     private final List<IModInfo> sortedList;
-    private final Map<String, ModFileInfo> fileById;
+    private final Map<String, IModFileInfo> fileById;
     private List<ModContainer> mods;
     private Map<String, ModContainer> indexedMods;
     private List<ModFileScanData> modFileScanData;
     private List<ModContainer> sortedContainers;
 
-    private ModList(final List<ModFile> modFiles, final List<ModInfo> sortedList)
+    private ModList(final List<IModFile> modFiles, final List<IModInfo> sortedList)
     {
-        this.modFiles = modFiles.stream().map(ModFile::getModFileInfo).map(ModFileInfo.class::cast).collect(Collectors.toList());
+        this.modFiles = modFiles.stream().map(IModFile::getModFileInfo).toList();
         this.sortedList = sortedList.stream().
                 map(ModInfo.class::cast).
                 collect(Collectors.toList());
         this.fileById = this.modFiles.stream().map(IModFileInfo::getMods).flatMap(Collection::stream).
-                map(ModInfo.class::cast).
-                collect(Collectors.toMap(ModInfo::getModId, ModInfo::getOwningFile));
+                collect(Collectors.toMap(IModInfo::getModId, IModInfo::getOwningFile));
         CrashReportCallables.registerCrashCallable("Mod List", this::crashReport);
     }
 
@@ -85,7 +84,7 @@ public class ModList
         return "\n"+applyForEachModFile(this::fileToLine).collect(Collectors.joining("\n\t\t", "\t\t", ""));
     }
 
-    public static ModList of(List<ModFile> modFiles, List<ModInfo> sortedList)
+    public static ModList of(List<IModFile> modFiles, List<IModInfo> sortedList)
     {
         INSTANCE = new ModList(modFiles, sortedList);
         return INSTANCE;

--- a/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
@@ -21,6 +21,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.loading.targets.CommonLaunchHandler;
 import net.neoforged.neoforgespi.Environment;
 import net.neoforged.neoforgespi.coremod.ICoreModProvider;
+import net.neoforged.neoforgespi.locating.IModFile;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -186,7 +187,7 @@ public class FMLLoader
         return commonLaunchHandler;
     }
 
-    public static void addAccessTransformer(Path atPath, ModFile modName)
+    public static void addAccessTransformer(Path atPath, IModFile modName)
     {
         LOGGER.debug(LogMarkers.SCAN, "Adding Access Transformer in {}", modName.getFilePath());
         try {

--- a/loader/src/main/java/net/neoforged/fml/loading/LanguageLoadingProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/LanguageLoadingProvider.java
@@ -12,6 +12,7 @@ import cpw.mods.modlauncher.util.ServiceLoaderUtils;
 import net.neoforged.neoforgespi.language.IModLanguageProvider;
 import net.neoforged.fml.loading.moddiscovery.ExplodedDirectoryLocator;
 import net.neoforged.fml.loading.moddiscovery.ModFile;
+import net.neoforged.neoforgespi.locating.IModFile;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.VersionRange;
@@ -129,7 +130,7 @@ public class LanguageLoadingProvider
         return languagePaths.stream();
     }
 
-    public IModLanguageProvider findLanguage(ModFile mf, String modLoader, VersionRange modLoaderVersion) {
+    public IModLanguageProvider findLanguage(IModFile mf, String modLoader, VersionRange modLoaderVersion) {
         final String languageFileName = mf.getProvider() instanceof ExplodedDirectoryLocator ? "in-development" : mf.getFileName();
         final ModLanguageWrapper mlw = languageProviderMap.get(modLoader);
         if (mlw == null) {

--- a/loader/src/main/java/net/neoforged/fml/loading/UniqueModListBuilder.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/UniqueModListBuilder.java
@@ -8,7 +8,9 @@ package net.neoforged.fml.loading;
 import com.mojang.logging.LogUtils;
 import net.neoforged.fml.loading.moddiscovery.ModFile;
 import net.neoforged.neoforgespi.language.IModInfo;
+import net.neoforged.neoforgespi.locating.IModFile;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
@@ -16,7 +18,9 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
+import java.util.jar.Attributes;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
@@ -27,21 +31,21 @@ public class UniqueModListBuilder
 {
     private final static Logger LOGGER = LogUtils.getLogger();
 
-    private final List<ModFile> modFiles;
+    private final List<IModFile> modFiles;
 
-    public UniqueModListBuilder(final List<ModFile> modFiles) {this.modFiles = modFiles;}
+    public UniqueModListBuilder(final List<IModFile> modFiles) {this.modFiles = modFiles;}
 
     public UniqueModListData buildUniqueList()
     {
-        List<ModFile> uniqueModList;
-        List<ModFile> uniqueLibListWithVersion;
+        List<IModFile> uniqueModList;
+        List<IModFile> uniqueLibListWithVersion;
 
         // Collect mod files by module name. This will be used for deduping purposes
-        final Map<String, List<ModFile>> modFilesByFirstId = modFiles.stream()
+        final Map<String, List<IModFile>> modFilesByFirstId = modFiles.stream()
                 .filter(mf -> mf.getModFileInfo() != null)
                 .collect(groupingBy(UniqueModListBuilder::getModId));
 
-        final Map<String, List<ModFile>> libFilesWithVersionByModuleName = modFiles.stream()
+        final Map<String, List<IModFile>> libFilesWithVersionByModuleName = modFiles.stream()
                 .filter(mf -> mf.getModFileInfo() == null)
                 .collect(groupingBy(UniqueModListBuilder::getModId));
 
@@ -58,12 +62,12 @@ public class UniqueModListBuilder
         // Transform to the full mod id list
         final Map<String, List<IModInfo>> modIds = uniqueModList.stream()
                 .filter(mf -> mf.getModFileInfo() != null) //Filter out non-mod files, we don't care about those for now.....
-                .map(ModFile::getModInfos)
+                .map(IModFile::getModInfos)
                 .flatMap(Collection::stream)
                 .collect(groupingBy(IModInfo::getModId));
 
         // Transform to the full lib id list
-        final Map<String, List<ModFile>> versionedLibIds = uniqueLibListWithVersion.stream()
+        final Map<String, List<IModFile>> versionedLibIds = uniqueLibListWithVersion.stream()
                 .map(UniqueModListBuilder::getModId)
                 .collect(Collectors.toMap(
                     Function.identity(),
@@ -104,18 +108,18 @@ public class UniqueModListBuilder
         }
 
         // Collect unique mod files by module name. This will be used for deduping purposes
-        final Map<String, List<ModFile>> uniqueModFilesByFirstId = uniqueModList.stream()
+        final Map<String, List<IModFile>> uniqueModFilesByFirstId = uniqueModList.stream()
                 .collect(groupingBy(UniqueModListBuilder::getModId));
 
-        final List<ModFile> loadedList = new ArrayList<>();
+        final List<IModFile> loadedList = new ArrayList<>();
         loadedList.addAll(uniqueModList);
         loadedList.addAll(uniqueLibListWithVersion);
 
         return new UniqueModListData(loadedList, uniqueModFilesByFirstId);
     }
 
-    private ModFile selectNewestModInfo(Map.Entry<String, List<ModFile>> fullList) {
-        List<ModFile> modInfoList = fullList.getValue();
+    private IModFile selectNewestModInfo(Map.Entry<String, List<IModFile>> fullList) {
+        List<IModFile> modInfoList = fullList.getValue();
         if (modInfoList.size() > 1) {
             LOGGER.debug("Found {} mods for first modid {}, selecting most recent based on version data", modInfoList.size(), fullList.getKey());
             modInfoList.sort(Comparator.comparing(this::getVersion).reversed());
@@ -124,16 +128,16 @@ public class UniqueModListBuilder
         return modInfoList.get(0);
     }
 
-    private ArtifactVersion getVersion(final ModFile mf)
+    private ArtifactVersion getVersion(final IModFile mf)
     {
         if (mf.getModFileInfo() == null || mf.getModInfos() == null || mf.getModInfos().isEmpty()) {
-            return mf.getJarVersion();
+            return mf.getVersion();
         }
 
         return mf.getModInfos().get(0).getVersion();
     }
 
-    private static String getModId(ModFile modFile) {
+    private static String getModId(IModFile modFile) {
         if (modFile.getModFileInfo() == null || modFile.getModFileInfo().getMods().isEmpty()) {
             return modFile.getSecureJar().name();
         }
@@ -141,6 +145,6 @@ public class UniqueModListBuilder
         return modFile.getModFileInfo().moduleName();
     }
 
-    public record UniqueModListData(List<ModFile> modFiles, Map<String, List<ModFile>> modFilesByFirstId) {}
+    public record UniqueModListData(List<IModFile> modFiles, Map<String, List<IModFile>> modFilesByFirstId) {}
 
 }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModDiscoverer.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModDiscoverer.java
@@ -63,7 +63,7 @@ public class ModDiscoverer {
 
     public ModValidator discoverMods() {
         LOGGER.debug(LogMarkers.SCAN,"Scanning for mods and other resources to load. We know {} ways to find mods", modLocatorList.size());
-        List<ModFile> loadedFiles = new ArrayList<>();
+        List<IModFile> loadedFiles = new ArrayList<>();
         List<EarlyLoadingException.ExceptionData> discoveryErrorData = new ArrayList<>();
         boolean successfullyLoadedMods = true;
         List<IModFileInfo> brokenFiles = new ArrayList<>();
@@ -100,7 +100,7 @@ public class ModDiscoverer {
         }
 
         //First processing run of the mod list. Any duplicates will cause resolution failure and dependency loading will be skipped.
-        Map<IModFile.Type, List<ModFile>> modFilesMap = Maps.newHashMap();
+        Map<IModFile.Type, List<IModFile>> modFilesMap = Maps.newHashMap();
         try {
             final UniqueModListBuilder modsUniqueListBuilder = new UniqueModListBuilder(loadedFiles);
             final UniqueModListBuilder.UniqueModListData uniqueModsData = modsUniqueListBuilder.buildUniqueList();
@@ -164,12 +164,11 @@ public class ModDiscoverer {
         return validator;
     }
 
-    private void handleLocatedFiles(final List<ModFile> loadedFiles, final List<IModFile> locatedFiles)
+    private void handleLocatedFiles(final List<IModFile> loadedFiles, final List<IModFile> locatedFiles)
     {
-        var locatedModFiles = locatedFiles.stream().filter(ModFile.class::isInstance).map(ModFile.class::cast).toList();
-        for (IModFile mf : locatedModFiles) {
+        for (IModFile mf : locatedFiles) {
             LOGGER.info(LogMarkers.SCAN, "Found mod file \"{}\" of type {} with provider {}", mf.getFileName(), mf.getType(), mf.getProvider());
         }
-        loadedFiles.addAll(locatedModFiles);
+        loadedFiles.addAll(locatedFiles);
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFileParser.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFileParser.java
@@ -10,6 +10,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.mojang.logging.LogUtils;
 import net.neoforged.fml.loading.LogMarkers;
+import net.neoforged.neoforgespi.coremod.ICoreModFile;
 import net.neoforged.neoforgespi.language.IModFileInfo;
 import net.neoforged.neoforgespi.locating.IModFile;
 import net.neoforged.neoforgespi.locating.ModFileFactory;
@@ -47,7 +48,7 @@ public class ModFileParser {
         return new ModFileInfo(modFile, configWrapper, configWrapper::setFile);
     }
 
-    protected static List<CoreModFile> getCoreMods(final ModFile modFile) {
+    protected static List<ICoreModFile> getCoreMods(final ModFile modFile) {
         Map<String,String> coreModPaths;
         try {
             final Path coremodsjson = modFile.findResource("META-INF", "coremods.json");
@@ -64,7 +65,7 @@ public class ModFileParser {
 
         return coreModPaths.entrySet().stream()
                 .peek(e-> LOGGER.debug(LogMarkers.LOADING,"Found coremod {} with Javascript path {}", e.getKey(), e.getValue()))
-                .map(e -> new CoreModFile(e.getKey(), modFile.findResource(e.getValue()),modFile))
+                .<ICoreModFile>map(e -> new CoreModFile(e.getKey(), modFile.findResource(e.getValue()),modFile))
                 .toList();
     }
 

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -5,6 +5,7 @@ plugins {
 }
 
 dependencies {
+    compileOnly("org.jetbrains:annotations:${jetbrains_annotations_version}")
     implementation("cpw.mods:modlauncher:$modlauncher_version")
     implementation("org.ow2.asm:asm:$asm_version")
     implementation("org.ow2.asm:asm-commons:$asm_version")

--- a/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
+++ b/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
@@ -6,11 +6,14 @@
 package net.neoforged.neoforgespi.locating;
 
 import cpw.mods.jarhandling.SecureJar;
+import net.neoforged.neoforgespi.coremod.ICoreModFile;
 import net.neoforged.neoforgespi.language.*;
 import net.neoforged.neoforgespi.language.IModFileInfo;
 import net.neoforged.neoforgespi.language.IModInfo;
 import net.neoforged.neoforgespi.language.IModLanguageProvider;
 import net.neoforged.neoforgespi.language.ModFileScanData;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -28,14 +31,7 @@ import java.util.function.Supplier;
  */
 public interface IModFile {
     /**
-     * The language loaders which are included in this mod file.
-     *
-     * If this method returns any entries then {@link #getType()} has to return {@link Type#LIBRARY},
-     * else this mod file will not be loaded in the proper module layer in 1.17 and above.
-     *
-     * As such, returning entries from this method is mutually exclusive with returning entries from {@link #getModInfos()}.
-     *
-     * @return The mod language providers provided by this mod file. (Also known as the loaders).
+     * {@return the language loaders that will load this mod}
      */
     List<IModLanguageProvider> getLoaders();
 
@@ -92,8 +88,6 @@ public interface IModFile {
      * If this method returns any entries then {@link #getType()} has to return {@link Type#MOD},
      * else this mod file will not be loaded in the proper module layer in 1.17 and above.
      *
-     * As such returning entries from this method is mutually exclusive with {@link #getLoaders()}.
-     *
      * @return The mods in this mod file.
      */
     List<IModInfo> getModInfos();
@@ -124,6 +118,36 @@ public interface IModFile {
      * @return The info for this file.
      */
     IModFileInfo getModFileInfo();
+
+    /**
+     * {@return the coremods contained in this file}
+     */
+    List<ICoreModFile> getCoreMods();
+
+    /**
+     * {@return the names of the Mixin configs of this file}
+     */
+    List<String> getMixinConfigs();
+
+    /**
+     * {@return the paths to the access transformer files contained in this file}
+     */
+    List<Path> getAccessTransformers();
+
+    /**
+     * {@return the controller of this file}
+     * This controller handles validating and computing information about the mods contained by the file. <p>
+     * The controller is mostly internal, for use by FML, and should only be used by implementors.
+     */
+    @ApiStatus.OverrideOnly
+    IModFileController getController();
+
+    /**
+     * {@return the version of this file}
+     * Usually this is the version in the jar's manifest.
+     * @apiNote This version may not be accurate, when possible, use the version of the mods contained in the file.
+     */
+    ArtifactVersion getVersion();
 
     /**
      * The type of file.

--- a/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFileController.java
+++ b/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFileController.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.neoforgespi.locating;
+
+import net.neoforged.neoforgespi.language.IModFileInfo;
+import net.neoforged.neoforgespi.language.IModLanguageProvider;
+import org.jetbrains.annotations.ApiStatus;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * A mod file controller controller handles validating and computing information about the mods contained by the file. <p>
+ * Controllers are mostly internal, for use by FML, and should only be used by implementors.
+ */
+@ApiStatus.OverrideOnly
+public interface IModFileController {
+    /**
+     * Called when the mods contained in the mod file shall be identified, and any other related information (such as AT files).
+     */
+    void identify();
+
+    /**
+     * Sets the loaders that will load the mod. <p>
+     * The loaders that will be received are defined by {@link IModFileInfo#requiredLanguageLoaders()}.
+     *
+     * @param loaders the loaders that will load the mod
+     */
+    void setLoaders(List<IModLanguageProvider> loaders);
+
+    /**
+     * Submit this file for content scanning. This includes computing the {@link IModFile#getScanResult() scan data} of the file.
+     */
+    CompletableFuture<?> submitForScanning(ExecutorService service);
+}


### PR DESCRIPTION
Removes the hard casts to `ModFile`, to make `IModFile` extendable. In order to achieve this, a few more methods were added to SPI.