### PR TITLE
Add source info for JarInJar mod

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/JarInJarDependencyLocator.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/JarInJarDependencyLocator.java
@@ -81,7 +81,9 @@ public class JarInJarDependencyLocator extends AbstractJarFileDependencyLocator
             final Map<String, ?> outerFsArgs = ImmutableMap.of("packagePath", pathInModFile);
             final FileSystem zipFS = FileSystems.newFileSystem(filePathUri, outerFsArgs);
             final Path pathInFS = zipFS.getPath("/");
-            return Optional.of(createMod(pathInFS).file());
+            Optional<IModFile> result = Optional.of(createMod(pathInFS).file());
+            result.ifPresent(mf -> mf.markJarInJarSource(file.getFileName()));
+            return result;
         }
         catch (Exception e)
         {

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModDiscoverer.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModDiscoverer.java
@@ -169,6 +169,10 @@ public class ModDiscoverer {
         var locatedModFiles = locatedFiles.stream().filter(ModFile.class::isInstance).map(ModFile.class::cast).toList();
         for (IModFile mf : locatedModFiles) {
             LOGGER.info(LogMarkers.SCAN, "Found mod file \"{}\" of type {} with provider {}", mf.getFileName(), mf.getType(), mf.getProvider());
+
+            if (!mf.getJarInJarSource().isEmpty()) {
+                LOGGER.info("{} is JarInJar mod, from list of mod: {}", mf.getFileName(), mf.getJarInJarSource().toString());
+            }
         }
         loadedFiles.addAll(locatedModFiles);
     }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFile.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFile.java
@@ -23,10 +23,7 @@ import org.slf4j.Logger;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
@@ -48,6 +45,7 @@ public class ModFile implements IModFile {
     private final Manifest     manifest;
     private final IModProvider provider;
     private       IModFileInfo modFileInfo;
+    private final List<String> jarInJarSource;
     private ModFileScanData fileModFileScanData;
     private volatile CompletableFuture<ModFileScanData> futureScanResult;
     private List<CoreModFile> coreMods;
@@ -70,6 +68,8 @@ public class ModFile implements IModFile {
         modFileType = Type.valueOf(type);
         jarVersion = Optional.ofNullable(manifest.getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION)).orElse("0.0NONE");
         this.modFileInfo = ModFileParser.readModList(this, this.parser);
+
+        jarInJarSource = new ArrayList<>();
     }
 
     @Override
@@ -209,6 +209,16 @@ public class ModFile implements IModFile {
     @Override
     public IModFileInfo getModFileInfo() {
         return modFileInfo;
+    }
+
+    @Override
+    public void markJarInJarSource(String fromJar) {
+        jarInJarSource.add(fromJar);
+    }
+
+    @Override
+    public List<String> getJarInJarSource() {
+        return jarInJarSource;
     }
 
     @Override

--- a/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
+++ b/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
@@ -126,6 +126,17 @@ public interface IModFile {
     IModFileInfo getModFileInfo();
 
     /**
+     * This method marks the IModFile, indicating that it contains or depends on another embedded JAR file.
+     * @param fromJar The name of the embedded JAR file. This parameter specifies the JAR file to be loaded as a Jij.
+     */
+    void markJarInJarSource(String fromJar);
+
+    /**
+     * @return source of the IModFile
+     */
+    List<String> getJarInJarSource();
+
+    /**
      * The type of file.
      * Determines into which module layer the data is loaded and how metadata is loaded and processed.
      */


### PR DESCRIPTION
I tried to add the trace of the JarInJar mod to be able to print out the source of the JarInJar mod, which is useful for debugging in some complex environments, such as some environments with dozens of mods, because some non-standard packaging behavior or wrong java module definition causes conflicts or even crashes, in this case I need to find out the source of JarInJar to help identify the problem.