### PR TITLE
[1.20.1] Prevent mixins from crashing the game when there are missing mods

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
@@ -16,7 +16,6 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
 import java.util.*;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -73,16 +72,18 @@ public class ModValidator {
     }
 
     public ITransformationService.Resource getModResources() {
-        Stream<ModFile> modFileStream = this.candidateMods.stream();
+        Stream<ModFile> modFileStream;
         if (FMLEnvironment.production) {
             // In production, only allow game libraries and/or mods in the loading mod list
             // This prevents custom mixins from loading if there is a dependency error
             // Usually, these mixins will break due to a missing class or AT, and that
             // will prevent our error screen from ever becoming visible.
-            Set<IModFile> validMods = new HashSet<>();
+            Set<ModFile> validMods = new HashSet<>();
             validMods.addAll(this.loadingModList.getModFiles().stream().map(ModFileInfo::getFile).toList());
             validMods.addAll(this.gameLibraries);
-            modFileStream = modFileStream.filter(validMods::contains);
+            modFileStream = validMods.stream();
+        } else {
+            modFileStream = this.candidateMods.stream();
         }
         return new ITransformationService.Resource(IModuleLayerManager.Layer.GAME, modFileStream.map(IModFile::getSecureJar).toList());
     }

--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModValidator.java
@@ -15,10 +15,8 @@ import net.minecraftforge.forgespi.locating.IModFile;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class ModValidator {
@@ -29,11 +27,13 @@ public class ModValidator {
     private LoadingModList loadingModList;
     private List<IModFile> brokenFiles;
     private final List<EarlyLoadingException.ExceptionData> discoveryErrorData;
+    private final List<ModFile> gameLibraries;
 
     public ModValidator(final Map<IModFile.Type, List<ModFile>> modFiles, final List<IModFileInfo> brokenFiles, final List<EarlyLoadingException.ExceptionData> discoveryErrorData) {
         this.modFiles = modFiles;
         this.candidateMods = lst(modFiles.get(IModFile.Type.MOD));
-        this.candidateMods.addAll(lst(modFiles.get(IModFile.Type.GAMELIBRARY)));
+        this.gameLibraries = lst(modFiles.get(IModFile.Type.GAMELIBRARY));
+        this.candidateMods.addAll(this.gameLibraries);
         this.candidatePlugins = lst(modFiles.get(IModFile.Type.LANGPROVIDER));
         this.candidatePlugins.addAll(lst(modFiles.get(IModFile.Type.LIBRARY)));
         this.discoveryErrorData = discoveryErrorData;
@@ -72,7 +72,22 @@ public class ModValidator {
     }
 
     public ITransformationService.Resource getModResources() {
-        return new ITransformationService.Resource(IModuleLayerManager.Layer.GAME, this.candidateMods.stream().map(IModFile::getSecureJar).toList());
+        Predicate<IModFile> shouldLoadResource;
+        if (FMLEnvironment.production) {
+            // In production, only allow game libraries and/or mods in the loading mod list
+            // This prevents custom mixins from loading if there is a dependency error
+            // Usually, these mixins will break due to a missing class or AT, and that
+            // will prevent our error screen from ever becoming visible.
+            Set<IModFile> validMods = new HashSet<>();
+            validMods.addAll(this.loadingModList.getModFiles().stream().map(ModFileInfo::getFile).toList());
+            validMods.addAll(this.gameLibraries);
+            shouldLoadResource = validMods::contains;
+        } else {
+            // In dev, allow any candidate mod to be loaded, as otherwise the --mixin.config argument
+            // will throw if there is a dependency error due to the mixin config being filtered.
+            shouldLoadResource = file -> true;
+        }
+        return new ITransformationService.Resource(IModuleLayerManager.Layer.GAME, this.candidateMods.stream().filter(shouldLoadResource).map(IModFile::getSecureJar).toList());
     }
 
     private List<EarlyLoadingException.ExceptionData> validateLanguages() {


### PR DESCRIPTION
The issue was fixed in newer FML versions by adding the new `[[mixin]]` syntax; this is a workaround for 1.20.1. I have copied the description from my original PR to MCF below.

----------------

In FML versions post-modularization, mixins are still loaded even if there is a missing dependency. Unfortunately, said mixins can attempt to load missing classes (causing a crash), or attempt to access a field that was transformed by an AT, which will not happen when there are loading errors, also causing a crash.

This PR solves the issue by not allowing mod resources to enter the classpath at all, preventing the mixin configs from being loaded which restores the 1.16 behavior. Now, the loading error screen will be properly shown instead of the game crashing with some random `ClassNotFoundException` or `IllegalAccessError`. This issue was particularly aggravating for support Discords as users report a "crash" when it's really just that they haven't installed a mod.

I have made the PR against 1.20.1, as that's the version I was using for testing. The test case I used in production is to install the mod Supplementaries, version 1.20-2.7.14, *without* installing its dependency, Moonlight Lib. Without this PR, the game crashes with `ClassMetadataNotFoundException`. If I replace the fmlloader JAR with one from this PR, the game reaches the loading error screen.

You'll notice that this change is disabled in dev. This is to prevent dev environments using `--mixin.config` from crashing if there is a dependency error due to the mixin file no longer being found. The issue is only really a problem for production environments, where users do not know to read their log and find the missing dependency error.