### PR TITLE
Add headers to crash report extenders

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/CrashReportCallables.java
+++ b/loader/src/main/java/net/neoforged/fml/CrashReportCallables.java
@@ -13,11 +13,13 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 public class CrashReportCallables
 {
     private static final Logger LOGGER = LogUtils.getLogger();
     private static final List<ISystemReportExtender> crashCallables = Collections.synchronizedList(new ArrayList<>());
+    private static final List<Supplier<String>> HEADERS = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Register a custom {@link ISystemReportExtender}
@@ -90,8 +92,21 @@ public class CrashReportCallables
         });
     }
 
+    /**
+     * Registers a header to be added to the top of crash reports.
+     *
+     * @param header the header
+     */
+    public static void registerHeader(Supplier<String> header) {
+        HEADERS.add(header);
+    }
+
     public static List<ISystemReportExtender> allCrashCallables()
     {
         return List.copyOf(crashCallables);
+    }
+
+    public static Stream<String> getHeaders() {
+        return HEADERS.stream().map(Supplier::get);
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/CrashReportCallables.java
+++ b/loader/src/main/java/net/neoforged/fml/CrashReportCallables.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -107,6 +108,6 @@ public class CrashReportCallables
     }
 
     public static Stream<String> getHeaders() {
-        return HEADERS.stream().map(ICrashReportHeader::getHeader);
+        return HEADERS.stream().map(ICrashReportHeader::getHeader).filter(Objects::nonNull);
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/CrashReportCallables.java
+++ b/loader/src/main/java/net/neoforged/fml/CrashReportCallables.java
@@ -19,7 +19,7 @@ public class CrashReportCallables
 {
     private static final Logger LOGGER = LogUtils.getLogger();
     private static final List<ISystemReportExtender> crashCallables = Collections.synchronizedList(new ArrayList<>());
-    private static final List<Supplier<String>> HEADERS = Collections.synchronizedList(new ArrayList<>());
+    private static final List<ICrashReportHeader> HEADERS = Collections.synchronizedList(new ArrayList<>());
 
     /**
      * Register a custom {@link ISystemReportExtender}
@@ -97,7 +97,7 @@ public class CrashReportCallables
      *
      * @param header the header
      */
-    public static void registerHeader(Supplier<String> header) {
+    public static void registerHeader(ICrashReportHeader header) {
         HEADERS.add(header);
     }
 
@@ -107,6 +107,6 @@ public class CrashReportCallables
     }
 
     public static Stream<String> getHeaders() {
-        return HEADERS.stream().map(Supplier::get);
+        return HEADERS.stream().map(ICrashReportHeader::getHeader);
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/ICrashReportHeader.java
+++ b/loader/src/main/java/net/neoforged/fml/ICrashReportHeader.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.fml;
 
 import java.util.function.Supplier;

--- a/loader/src/main/java/net/neoforged/fml/ICrashReportHeader.java
+++ b/loader/src/main/java/net/neoforged/fml/ICrashReportHeader.java
@@ -1,0 +1,15 @@
+package net.neoforged.fml;
+
+import java.util.function.Supplier;
+
+/**
+ * Supplies a header to add to crash reports.
+ * @see CrashReportCallables#registerHeader(Supplier)
+ */
+@FunctionalInterface
+public interface ICrashReportHeader {
+    /**
+     * {@return the header to be displayed at the top of the crash report}
+     */
+    String getHeader();
+}

--- a/loader/src/main/java/net/neoforged/fml/ICrashReportHeader.java
+++ b/loader/src/main/java/net/neoforged/fml/ICrashReportHeader.java
@@ -5,16 +5,17 @@
 
 package net.neoforged.fml;
 
-import java.util.function.Supplier;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Supplies a header to add to crash reports.
- * @see CrashReportCallables#registerHeader(Supplier)
+ * @see CrashReportCallables#registerHeader(ICrashReportHeader)
  */
 @FunctionalInterface
 public interface ICrashReportHeader {
     /**
-     * {@return the header to be displayed at the top of the crash report}
+     * {@return the header to be displayed at the top of the crash report, or {@code null} if the header shouldn't be added}
      */
+    @Nullable
     String getHeader();
 }

--- a/loader/src/main/java/net/neoforged/fml/ISystemReportExtender.java
+++ b/loader/src/main/java/net/neoforged/fml/ISystemReportExtender.java
@@ -6,36 +6,13 @@
 package net.neoforged.fml;
 
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.function.Supplier;
 
 @ApiStatus.OverrideOnly
-public interface ISystemReportExtender extends Supplier<String> {
-    /**
-     * {@return the label of the crash report value to add}
-     */
-    @Nullable
-    default String getLabel() {
-        return null;
-    }
-
-    /**
-     * {@return the value to add to the crash report}
-     */
-    @Nullable
-    @Override
-    default String get() {
-        return null;
-    }
-
-    /**
-     * {@return a header to add to the crash report}
-     */
-    @Nullable
-    default String getHeader() {
-        return null;
-    }
+public interface ISystemReportExtender extends Supplier<String>
+{
+    String getLabel();
 
     default boolean isActive() {
         return true;

--- a/loader/src/main/java/net/neoforged/fml/ISystemReportExtender.java
+++ b/loader/src/main/java/net/neoforged/fml/ISystemReportExtender.java
@@ -5,14 +5,39 @@
 
 package net.neoforged.fml;
 
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.function.Supplier;
 
-public interface ISystemReportExtender extends Supplier<String>
-{
-    String getLabel();
+@ApiStatus.OverrideOnly
+public interface ISystemReportExtender extends Supplier<String> {
+    /**
+     * {@return the label of the crash report value to add}
+     */
+    @Nullable
+    default String getLabel() {
+        return null;
+    }
 
-    default boolean isActive()
-    {
+    /**
+     * {@return the value to add to the crash report}
+     */
+    @Nullable
+    @Override
+    default String get() {
+        return null;
+    }
+
+    /**
+     * {@return a header to add to the crash report}
+     */
+    @Nullable
+    default String getHeader() {
+        return null;
+    }
+
+    default boolean isActive() {
         return true;
     }
 }


### PR DESCRIPTION
Neo already has a hook to add a crash report header, but the method contents are empty. This PR allows crash report extenders to add headers to crash reports.  

Connector can, for instance, use this to show a warning at the top of the report telling users to not report the crash to mod authors.