### PR TITLE
ModInfo i18n API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@
 changelog.txt
 *.py
 *.7z
-/logs/
+logs/
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,8 +38,16 @@ allprojects {
             url = 'https://libraries.minecraft.net'
         }
 
-        // TODO remove
         mavenLocal()
+    }
+
+    dependencies {
+        testRuntimeOnly("org.apache.logging.log4j:log4j-core:$log4j_version")
+        testImplementation(platform("org.junit:junit-bom:$jupiter_version"))
+        testImplementation("org.junit.jupiter:junit-jupiter")
+        testImplementation("org.mockito:mockito-core:$mockito_version")
+        testImplementation("org.mockito:mockito-junit-jupiter:$mockito_version")
+        testImplementation("org.hamcrest:hamcrest-core:2.2+")
     }
 
     dependencyUpdates.rejectVersionIf { isNonStable(it.candidate.version) }

--- a/earlydisplay/build.gradle
+++ b/earlydisplay/build.gradle
@@ -24,11 +24,7 @@ dependencies {
     implementation("org.lwjgl:lwjgl-tinyfd:${lwjgl_version}")
     implementation("org.slf4j:slf4j-api:${slf4j_api_version}")
     implementation("net.sf.jopt-simple:jopt-simple:${jopt_simple_version}")
-    
-    testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiter_version}")
-    testImplementation("org.powermock:powermock-core:${powermock_version}")
-    
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiter_version}")
+
     testRuntimeOnly("org.slf4j:slf4j-jdk14:${slf4j_api_version}")
     testRuntimeOnly("org.lwjgl:lwjgl::${lwjglNatives}")
     testRuntimeOnly("org.lwjgl:lwjgl-glfw::${lwjglNatives}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ apache_maven_artifact_version=3.8.5
 jarjar_version=0.4.0
 lwjgl_version=3.3.1
 jupiter_version=5.8.2
-powermock_version=2.0.9
+mockito_version=5.10.0
 
 mojang_logging_version=1.1.1
 log4j_version=2.19.0

--- a/loader/src/main/java/net/neoforged/fml/Bindings.java
+++ b/loader/src/main/java/net/neoforged/fml/Bindings.java
@@ -14,7 +14,7 @@ import java.util.ServiceLoader;
 import java.util.function.Supplier;
 
 public class Bindings {
-    private static final Bindings INSTANCE = new Bindings();
+    private static Bindings instance;
 
     private final IBindingsProvider provider;
 
@@ -26,15 +26,23 @@ public class Bindings {
         this.provider = providers.get(0);
     }
 
+    private static Bindings getInstance() {
+        if (instance == null) {
+            instance = new Bindings();
+        }
+        return instance;
+    }
+
+
     public static Supplier<IEventBus> getForgeBus() {
-        return INSTANCE.provider.getForgeBusSupplier();
+        return getInstance().provider.getForgeBusSupplier();
     }
 
     public static Supplier<I18NParser> getMessageParser() {
-        return INSTANCE.provider.getMessageParser();
+        return getInstance().provider.getMessageParser();
     }
 
     public static Supplier<IConfigEvent.ConfigConfig> getConfigConfiguration() {
-        return INSTANCE.provider.getConfigConfiguration();
+        return getInstance().provider.getConfigConfiguration();
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -6,6 +6,8 @@
 package net.neoforged.fml.loading.moddiscovery;
 
 import com.mojang.logging.LogUtils;
+import net.neoforged.fml.Bindings;
+import net.neoforged.fml.I18NParser;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.StringSubstitutor;
 import net.neoforged.fml.loading.StringUtils;
@@ -19,11 +21,7 @@ import org.apache.maven.artifact.versioning.VersionRange;
 import org.slf4j.Logger;
 
 import java.net.URL;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 
 public class ModInfo implements IModInfo, IConfigurable
@@ -127,9 +125,25 @@ public class ModInfo implements IModInfo, IConfigurable
     }
 
     @Override
+    public String getDisplayNameTranslated()
+    {
+        String i18n = "fml.menu.mods.info.name." + this.getModId();
+        String name = Bindings.getMessageParser().get().parseMessage(i18n);
+        return Objects.equals(i18n, name) ? this.getDisplayName() : name;
+    }
+
+    @Override
     public String getDescription()
     {
         return this.description;
+    }
+
+    @Override
+    public String getDescriptionTranslated()
+    {
+        String i18n = "fml.menu.mods.info.description." + this.getModId();
+        String description = Bindings.getMessageParser().get().parseMessage(i18n);
+        return Objects.equals(i18n, description) ? this.getDescription() : description;
     }
 
     @Override

--- a/loader/src/test/java/net/neoforged/fml/loading/moddiscovery/ModInfoTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/moddiscovery/ModInfoTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.fml.loading.moddiscovery;
+
+import com.google.common.base.Supplier;
+import net.neoforged.fml.Bindings;
+import net.neoforged.fml.I18NParser;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ModInfoTest {
+
+    private static final String NAME_KEY = "fml.menu.mods.info.name.";
+    private static final String DESCRIPTION_KEY = "fml.menu.mods.info.description.";
+
+    private MockedStatic<Bindings> mockedBindings;
+    private @Mock ModInfo modInfo;
+    private @Mock I18NParser parser;
+
+    @BeforeEach
+    public void setup() {
+        mockedBindings = mockStatic(Bindings.class);
+        mockedBindings.when(Bindings::getMessageParser).thenReturn((Supplier<I18NParser>) () -> parser);
+    }
+
+    @AfterEach
+    public void teardown() {
+        mockedBindings.close();
+    }
+
+    @Test
+    @DisplayName("Use translated name if present")
+    public void testTranslatedDisplayName() {
+        String id = "modid";
+        String i18n = NAME_KEY + id;
+        String expected = "Translated name";
+
+        when(parser.parseMessage(i18n)).thenReturn(expected);
+        when(modInfo.getModId()).thenReturn(id);
+        when(modInfo.getDisplayNameTranslated()).thenCallRealMethod();
+
+        assertEquals(expected, modInfo.getDisplayNameTranslated());
+    }
+
+    @Test
+    @DisplayName("Use translated description if present")
+    public void testTranslatedDescription() {
+        String id = "modid";
+        String i18n = DESCRIPTION_KEY + id;
+        String expected = "Translated description";
+
+        when(parser.parseMessage(i18n)).thenReturn(expected);
+        when(modInfo.getModId()).thenReturn(id);
+        when(modInfo.getDescriptionTranslated()).thenCallRealMethod();
+
+        assertEquals(expected, modInfo.getDescriptionTranslated());
+    }
+
+    @Test
+    @DisplayName("Use untranslated name when translation fails")
+    public void testUntranslatedDisplayName() {
+        String id = "modid";
+        String i18n = NAME_KEY + id;
+        String expected = "Raw name";
+
+        // parser returns i18n key when translation is not found
+        when(parser.parseMessage(i18n)).thenReturn(i18n);
+
+        when(modInfo.getModId()).thenReturn(id);
+        when(modInfo.getDisplayName()).thenReturn(expected);
+        when(modInfo.getDisplayNameTranslated()).thenCallRealMethod();
+
+        assertEquals(expected, modInfo.getDisplayNameTranslated());
+    }
+
+    @Test
+    @DisplayName("Use untranslated description when translation fails")
+    public void testUntranslatedDescription() {
+        String id = "modid";
+        String i18n = DESCRIPTION_KEY + id;
+        String expected = "Raw description";
+
+        // parser returns i18n key when translation is not found
+        when(parser.parseMessage(i18n)).thenReturn(i18n);
+
+        when(modInfo.getModId()).thenReturn(id);
+        when(modInfo.getDescription()).thenReturn(expected);
+        when(modInfo.getDescriptionTranslated()).thenCallRealMethod();
+
+        assertEquals(expected, modInfo.getDescriptionTranslated());
+    }
+}

--- a/spi/build.gradle
+++ b/spi/build.gradle
@@ -15,15 +15,4 @@ dependencies {
     api("net.neoforged:mergetool:$mergetool_version:api") {
         transitive false
     }
-
-
-    testRuntimeOnly("org.apache.logging.log4j:log4j-core:$log4j_version")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$jupiter_version")
-    testImplementation("org.powermock:powermock-core:$powermock_version")
-    testImplementation("org.hamcrest:hamcrest-core:2.2+")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine:$jupiter_version")
-}
-
-test {
-    useJUnitPlatform()
 }

--- a/spi/src/main/java/net/neoforged/neoforgespi/language/IModInfo.java
+++ b/spi/src/main/java/net/neoforged/neoforgespi/language/IModInfo.java
@@ -28,7 +28,11 @@ public interface IModInfo
 
     String getDisplayName();
 
+    String getDisplayNameTranslated();
+
     String getDescription();
+
+    String getDescriptionTranslated();
 
     ArtifactVersion getVersion();
 


### PR DESCRIPTION
This PR provides a general i18n API to `IModInfo` that could be used in Neoforged to implement https://github.com/neoforged/NeoForge/issues/639.

I've added a unit test to cover the new behavior, however (as a new contributor) I'm unclear on the best way to test the functionality _in game_.

That said, if these assumptions are correct, then everything should work as intended:

- [ ] The `I18NParser` implementation that uses `I18NExtension` will return the i18n key when a translation is not present.
- [ ] `I18NParser`'s `i18n` map contains (at least) the same entries as Minecraft's `Language` instance.
- [ ] `I18NParser`'s `i18n` map is updated by `LanguageManager` when the language is changed or resource pakcs are reloaded.

### Using the API

Translations from mod display name and description can be provided by adding the following keys to lang files:
- `"fml.menu.mods.info.name.[modid]"`
- `"fml.menu.mods.info.description.[modid]"`
Where `[modid]` should be replaced with the actual mod ID.

These can then be accessed using new methods added to `IModInfo` (names subject to change):
- `IModInfo.getDisplayNameTranslated()`
- `IModInfo.getDescriptionTranslated()`
Which return the translated string (if one exists), or the string defined in `mods.toml` otherwise.

This could instead return an `Optional` or nullable value if preferred? That way you could easily check if a translated name/description exists and explicitly fallback using `Optional::orElseGet`.

### Tests

I've added a unit test for the new behavior. In order to do so, I had to make some preparatory changes elsewhere, which I've kept to their own commits for clarity.

As unit tests, they cannot check the assumptions I outlined above.