### PR TITLE
Only log errors when scanning mod file contents

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/Scanner.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/Scanner.java
@@ -41,14 +41,13 @@ public class Scanner {
     }
 
     private void fileVisitor(final Path path, final ModFileScanData result) {
-        LOGGER.debug(LogMarkers.SCAN,"Scanning {} path {}", fileToScan, path);
         try (InputStream in = Files.newInputStream(path)){
             ModClassVisitor mcv = new ModClassVisitor();
             ClassReader cr = new ClassReader(in);
             cr.accept(mcv, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
             mcv.buildData(result.getClasses(), result.getAnnotations());
         } catch (IOException | IllegalArgumentException e) {
-            // mark path bad
+            LOGGER.error(LogMarkers.SCAN,"Exception scanning {} path {}", fileToScan, path, e);
         }
     }
 }


### PR DESCRIPTION
Printing a debug-level log for every file path is problematic for two reasons:

* It creates a mess of the `debug.log` file, as there's a huge quantity of lines from the scanner at the beginning.
* It slows down launching the game (on my system, about 50% of the CPU time for the scanner threads is spent logging, rather than scanning).
Snippet from profiler showing the bottleneck:

![image](https://github.com/neoforged/FancyModLoader/assets/42941056/fa6d05d1-2c19-4c87-93c6-1698351f1780)


This information isn't that useful to log in bulk since one could just examine the mod JAR manually to know what files it contains. Instead, we just log if an exception occurs while scanning a given path.

