### PR TITLE
Add `registerConfig` method to `ModContainer`

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModContainer.java
+++ b/loader/src/main/java/net/neoforged/fml/ModContainer.java
@@ -160,6 +160,10 @@ public abstract class ModContainer
         addConfig(new ModConfig(type, configSpec, this));
     }
 
+    public void registerConfig(ModConfig.Type type, IConfigSpec<?> configSpec, String fileName) {
+        addConfig(new ModConfig(type, configSpec, this, fileName));
+    }
+
     /**
      * Does this mod match the supplied mod?
      *

--- a/loader/src/main/java/net/neoforged/fml/ModContainer.java
+++ b/loader/src/main/java/net/neoforged/fml/ModContainer.java
@@ -156,11 +156,37 @@ public abstract class ModContainer
        configs.put(modConfig.getType(), modConfig);
     }
 
+    /**
+     * Adds a {@link ModConfig} with the given type and spec. An empty config spec will be ignored and a debug line will
+     * be logged.
+     * @param type The type of config
+     * @param configSpec A config spec
+     */
     public void registerConfig(ModConfig.Type type, IConfigSpec<?> configSpec) {
+        if (configSpec.isEmpty())
+        {
+            // This handles the case where a mod tries to register a config, without any options configured inside it.
+            LOGGER.debug("Attempted to register an empty config for type {} on mod {}", type, modId);
+            return;
+        }
+
         addConfig(new ModConfig(type, configSpec, this));
     }
 
+    /**
+     * Adds a {@link ModConfig} with the given type, spec, and overridden file name. An empty config spec will be
+     * ignored and a debug line will be logged.
+     * @param type The type of config
+     * @param configSpec A config spec
+     */
     public void registerConfig(ModConfig.Type type, IConfigSpec<?> configSpec, String fileName) {
+        if (configSpec.isEmpty())
+        {
+            // This handles the case where a mod tries to register a config, without any options configured inside it.
+            LOGGER.debug("Attempted to register an empty config for type {} on mod {} using file name {}", type, modId, fileName);
+            return;
+        }
+
         addConfig(new ModConfig(type, configSpec, this, fileName));
     }
 

--- a/loader/src/main/java/net/neoforged/fml/ModContainer.java
+++ b/loader/src/main/java/net/neoforged/fml/ModContainer.java
@@ -9,6 +9,7 @@ import net.neoforged.bus.api.BusBuilder;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.config.IConfigSpec;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.fml.loading.progress.ProgressMeter;
@@ -153,6 +154,10 @@ public abstract class ModContainer
 
     public void addConfig(final ModConfig modConfig) {
        configs.put(modConfig.getType(), modConfig);
+    }
+
+    public void registerConfig(ModConfig.Type type, IConfigSpec<?> configSpec) {
+        addConfig(new ModConfig(type, configSpec, this));
     }
 
     /**

--- a/loader/src/main/java/net/neoforged/fml/ModLoadingContext.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoadingContext.java
@@ -48,25 +48,19 @@ public class ModLoadingContext
         getActiveContainer().registerExtensionPoint(point, extension);
     }
 
+    /**
+     * @deprecated Use the corresponding method {@link ModContainer#registerConfig(ModConfig.Type, IConfigSpec)}
+     */
+    @Deprecated(forRemoval = true)
     public void registerConfig(ModConfig.Type type, IConfigSpec<?> spec) {
-        if (spec.isEmpty())
-        {
-            // This handles the case where a mod tries to register a config, without any options configured inside it.
-            LOGGER.debug("Attempted to register an empty config for type {} on mod {}", type, getActiveContainer().getModId());
-            return;
-        }
-
         getActiveContainer().registerConfig(type, spec);
     }
 
+    /**
+     * @deprecated Use the corresponding method {@link ModContainer#registerConfig(ModConfig.Type, IConfigSpec, String)}
+     */
+    @Deprecated(forRemoval = true)
     public void registerConfig(ModConfig.Type type, IConfigSpec<?> spec, String fileName) {
-        if (spec.isEmpty())
-        {
-            // This handles the case where a mod tries to register a config, without any options configured inside it.
-            LOGGER.debug("Attempted to register an empty config for type {} on mod {} using file name {}", type, getActiveContainer().getModId(), fileName);
-            return;
-        }
-
         getActiveContainer().registerConfig(type, spec, fileName);
     }
 

--- a/loader/src/main/java/net/neoforged/fml/ModLoadingContext.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoadingContext.java
@@ -56,7 +56,7 @@ public class ModLoadingContext
             return;
         }
 
-        getActiveContainer().addConfig(new ModConfig(type, spec, getActiveContainer()));
+        getActiveContainer().registerConfig(type, spec);
     }
 
     public void registerConfig(ModConfig.Type type, IConfigSpec<?> spec, String fileName) {
@@ -67,7 +67,7 @@ public class ModLoadingContext
             return;
         }
 
-        getActiveContainer().addConfig(new ModConfig(type, spec, getActiveContainer(), fileName));
+        getActiveContainer().registerConfig(type, spec, fileName);
     }
 
 


### PR DESCRIPTION
Adds a method to `ModContainer` to create and add a mod config from a given type and spec. This is added to simplify the current verbose `addConfig` method. I understand that the config system is currently being looked at for a future refactor and as such recognize that the lifetime of this method may be short.