### PR TITLE
Rename mods.toml to neoforge.mods.toml

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoader.java
@@ -14,6 +14,7 @@ import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.fml.loading.FMLLoader;
 import net.neoforged.fml.loading.ImmediateWindowHandler;
 import net.neoforged.fml.loading.LoadingModList;
+import net.neoforged.fml.loading.moddiscovery.AbstractModProvider;
 import net.neoforged.fml.loading.moddiscovery.InvalidModIdentifier;
 import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.fml.loading.moddiscovery.ModInfo;
@@ -277,7 +278,7 @@ public class ModLoader
 
             var missingClasses = new ArrayList<>(modIds);
             missingClasses.removeAll(containerIds);
-            LOGGER.fatal(LOADING, "The following classes are missing, but are reported in the mods.toml: {}", missingClasses);
+            LOGGER.fatal(LOADING, "The following classes are missing, but are reported in the {}: {}", AbstractModProvider.MODS_TOML, missingClasses);
 
             var missingMods = new ArrayList<>(containerIds);
             missingMods.removeAll(modIds);

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/AbstractModProvider.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 public abstract class AbstractModProvider implements IModProvider
 {
     private static final   Logger LOGGER    = LogUtils.getLogger();
-    protected static final String MODS_TOML = "META-INF/mods.toml";
+    public static final String MODS_TOML = "neoforge.mods.toml";
     protected static final String MANIFEST = "META-INF/MANIFEST.MF";
 
     protected IModLocator.ModFileOrException createMod(Path... path) {

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/AbstractModProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/AbstractModProvider.java
@@ -29,7 +29,7 @@ import java.util.function.Function;
 public abstract class AbstractModProvider implements IModProvider
 {
     private static final   Logger LOGGER    = LogUtils.getLogger();
-    public static final String MODS_TOML = "neoforge.mods.toml";
+    public static final String MODS_TOML = "META-INF/neoforge.mods.toml";
     protected static final String MANIFEST = "META-INF/MANIFEST.MF";
 
     protected IModLocator.ModFileOrException createMod(Path... path) {

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ExplodedDirectoryLocator.java
@@ -41,7 +41,7 @@ public class ExplodedDirectoryLocator implements IModLocator {
                 mjm.setModFile(mf);
                 mods.put(explodedMod, mf);
             } else {
-                LOGGER.warn(LogMarkers.LOADING, "Failed to find exploded resource mods.toml in directory {}", explodedMod.paths().get(0).toString());
+                LOGGER.warn(LogMarkers.LOADING, "Failed to find exploded resource {} in directory {}", AbstractModProvider.MODS_TOML, explodedMod.paths().get(0).toString());
             }
         });
         return mods.values().stream().map(mf->new IModLocator.ModFileOrException(mf, null)).toList();

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFileParser.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFileParser.java
@@ -34,9 +34,9 @@ public class ModFileParser {
     public static IModFileInfo modsTomlParser(final IModFile imodFile) {
         ModFile modFile = (ModFile) imodFile;
         LOGGER.debug(LogMarkers.LOADING,"Considering mod file candidate {}", modFile.getFilePath());
-        final Path modsjson = modFile.findResource("META-INF", "mods.toml");
+        final Path modsjson = modFile.findResource(AbstractModProvider.MODS_TOML);
         if (!Files.exists(modsjson)) {
-            LOGGER.warn(LogMarkers.LOADING, "Mod file {} is missing mods.toml file", modFile.getFilePath());
+            LOGGER.warn(LogMarkers.LOADING, "Mod file {} is missing {} file", modFile.getFilePath(), AbstractModProvider.MODS_TOML);
             return null;
         }
 

--- a/loader/src/main/java/net/neoforged/fml/loading/targets/CommonDevLaunchHandler.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/targets/CommonDevLaunchHandler.java
@@ -9,6 +9,7 @@ import cpw.mods.jarhandling.JarContentsBuilder;
 import cpw.mods.jarhandling.SecureJar;
 import cpw.mods.niofs.union.UnionPathFilter;
 import net.neoforged.fml.loading.FileUtils;
+import net.neoforged.fml.loading.moddiscovery.AbstractModProvider;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -119,7 +120,7 @@ public abstract class CommonDevLaunchHandler extends CommonLaunchHandler {
     }
 
     protected String[] getExcludedPrefixes() {
-        return new String[]{ "net/neoforged/neoforge/", "META-INF/services/", "META-INF/coremods.json", "META-INF/mods.toml" };
+        return new String[]{ "net/neoforged/neoforge/", "META-INF/services/", "META-INF/coremods.json", AbstractModProvider.MODS_TOML};
     }
 
     private static String getRandomNumbers(int length) {


### PR DESCRIPTION
This is targeted for a new major (in 1.20.5).  
By renaming the file, we can improve error reporting in case Forge mods are found, and not attempt to load them. 3rd party tools can also use the presence or absence of this file to determine the loader of the mod.