### PR TITLE
[1.20.1] Backport some fixes from main

### DIFF
--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileDependencyLocator.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileDependencyLocator.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -25,7 +26,7 @@ public abstract class AbstractJarFileDependencyLocator extends AbstractJarFileMo
         try {
             return Optional.of(Files.newInputStream(modFile.findResource(path.toString())));
         }
-        catch (final FileNotFoundException e) {
+        catch (final FileNotFoundException | NoSuchFileException e) {
             LOGGER.debug("Failed to load resource {} from {}, it does not contain dependency information.", path, modFile.getFileName());
             return Optional.empty();
         }

--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileDependencyLocator.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/AbstractJarFileDependencyLocator.java
@@ -27,7 +27,7 @@ public abstract class AbstractJarFileDependencyLocator extends AbstractJarFileMo
             return Optional.of(Files.newInputStream(modFile.findResource(path.toString())));
         }
         catch (final FileNotFoundException | NoSuchFileException e) {
-            LOGGER.debug("Failed to load resource {} from {}, it does not contain dependency information.", path, modFile.getFileName());
+            LOGGER.trace("Failed to load resource {} from {}, it does not contain dependency information.", path, modFile.getFileName());
             return Optional.empty();
         }
         catch (final Exception e) {

--- a/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
+++ b/loader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/Scanner.java
@@ -45,14 +45,13 @@ public class Scanner {
     }
 
     private void fileVisitor(final Path path, final ModFileScanData result) {
-        LOGGER.debug(LogMarkers.SCAN,"Scanning {} path {}", fileToScan, path);
         try (InputStream in = Files.newInputStream(path)){
             ModClassVisitor mcv = new ModClassVisitor();
             ClassReader cr = new ClassReader(in);
             cr.accept(mcv, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG);
             mcv.buildData(result.getClasses(), result.getAnnotations());
         } catch (IOException | IllegalArgumentException e) {
-            // mark path bad
+            LOGGER.error(LogMarkers.SCAN,"Exception scanning {} path {}", fileToScan, path, e);
         }
     }
 }


### PR DESCRIPTION
This PR makes two changes:

* Catch `NoSuchFileException` as well as `FileNotFoundException` in `AbstractJarFileDependencyLocator`. This allows running with the latest SJH without seeing a few ugly errors on startup (they are harmless, but we may as well hide them).
* Backport #95 to 1.20.1, as the performance issue also exists on that version.