### PR TITLE
Remove FMLModType.LANGPROVIDER (you can use LIBRARY instead)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ subprojects { subProject ->
                 'Git-Commit'  : gradleutils.gitInfo.abbreviatedId,
                 'Build-Number': "${subProject.version}",
                 'Automatic-Module-Name' : "fml_${subProject.name.replace("-", "_")}",
-                'FMLModType'  : subProject.name.startsWith("language") ? 'LANGPROVIDER' : subProject.name == "events" ? 'GAMELIBRARY' : 'LIBRARY',
+                'FMLModType'  : 'LIBRARY',
                 'Specification-Title'   : "FML${subProject.name}",
                 'Specification-Vendor'  : 'NeoForged',
                 'Specification-Version' : "${subProject.version.toString().split('\\.')[0]}",

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModValidator.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModValidator.java
@@ -35,8 +35,7 @@ public class ModValidator {
         this.modFiles = modFiles;
         this.candidateMods = lst(modFiles.get(IModFile.Type.MOD));
         this.candidateMods.addAll(lst(modFiles.get(IModFile.Type.GAMELIBRARY)));
-        this.candidatePlugins = lst(modFiles.get(IModFile.Type.LANGPROVIDER));
-        this.candidatePlugins.addAll(lst(modFiles.get(IModFile.Type.LIBRARY)));
+        this.candidatePlugins = lst(modFiles.get(IModFile.Type.LIBRARY));
         this.discoveryErrorData = discoveryErrorData;
         this.brokenFiles = brokenFiles.stream().map(IModFileInfo::getFile).collect(Collectors.toList()); // mutable list
     }

--- a/spi/src/main/java/net/neoforged/neoforgespi/language/IModLanguageProvider.java
+++ b/spi/src/main/java/net/neoforged/neoforgespi/language/IModLanguageProvider.java
@@ -19,14 +19,17 @@
 
 package net.neoforged.neoforgespi.language;
 
+import net.neoforged.neoforgespi.locating.IModFile;
+
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
- * Loaded as a ServiceLoader, from the classpath. ExtensionPoint are loaded from
- * the mods directory, with the FMLType META-INF of LANGPROVIDER.
+ * Loaded as a ServiceLoader, from the plugin layer.
+ * Jars in the mods directory must have an {@code FMLModType} of {@link IModFile.Type#LIBRARY}
+ * to be loaded on the plugin layer.
  *
- * Version data is read from the manifest's implementation version.
+ * <p>Version data is read from the manifest's implementation version.
  */
 public interface IModLanguageProvider
 {

--- a/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
+++ b/spi/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
@@ -131,19 +131,16 @@ public interface IModFile {
      */
     enum Type {
         /**
-         * A mod file holds mod code and loads in the game module layer
+         * A mod file holds mod code and loads in the game module layer.
          */
         MOD,
         /**
-         * A library can reference lang providers in the plugin module layer
+         * A library can provide lang providers in the plugin module layer,
+         * and/or provides code that is not mod- or Minecraft- related.
          */
         LIBRARY,
         /**
-         * A language provider provides a custom way to load mods in the plugin module layer
-         */
-        LANGPROVIDER,
-        /**
-         * A game library can reference MC code and loads in the game module layer
+         * A game library can reference MC code and loads in the game module layer.
          */
         GAMELIBRARY
     }


### PR DESCRIPTION
There was in fact no reason to have this separate mod type - it didn't do anything special.

Closes #71.