### PR TITLE
Possibility to modify NeoForge group

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/FMLServiceProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLServiceProvider.java
@@ -36,6 +36,7 @@ public class FMLServiceProvider implements ITransformationService
     private ArgumentAcceptingOptionSpec<String> mcOption;
     private ArgumentAcceptingOptionSpec<String> mcpOption;
     private ArgumentAcceptingOptionSpec<String> mappingsOption;
+    private ArgumentAcceptingOptionSpec<String> groupOption;
     private List<String> modsArgumentList;
     private List<String> modListsArgumentList;
     private List<String> mavenRootsArgumentList;
@@ -45,6 +46,7 @@ public class FMLServiceProvider implements ITransformationService
     private String targetMcVersion;
     private String targetMcpVersion;
     private String targetMcpMappings;
+    private String neoForgeGroup;
     private Map<String, Object> arguments;
 
     public FMLServiceProvider()
@@ -76,6 +78,7 @@ public class FMLServiceProvider implements ITransformationService
         arguments.put("mcVersion", targetMcVersion);
         arguments.put("neoFormVersion", targetMcpVersion);
         arguments.put("mcpMappings", targetMcpMappings);
+        arguments.put("neoForgeGroup", neoForgeGroup);
         LOGGER.debug(CORE, "Preparing launch handler");
         FMLLoader.setupLaunchHandler(environment, arguments);
         FMLEnvironment.setupInteropEnvironment(environment);
@@ -110,6 +113,7 @@ public class FMLServiceProvider implements ITransformationService
         mcOption = argumentBuilder.apply("mcVersion", "Minecraft Version number").withRequiredArg().ofType(String.class).required();
         mcpOption = argumentBuilder.apply("neoFormVersion", "MCP Version number").withRequiredArg().ofType(String.class).required();
         mappingsOption = argumentBuilder.apply("mcpMappings", "MCP Mappings Channel and Version").withRequiredArg().ofType(String.class);
+        groupOption = argumentBuilder.apply("neoForgeGroup", "NeoForge artifact group").withRequiredArg().ofType(String.class).required();
         modsOption = argumentBuilder.apply("mods", "List of mods to add").withRequiredArg().ofType(String.class).withValuesSeparatedBy(",");
         modListsOption = argumentBuilder.apply("modLists", "JSON modlists").withRequiredArg().ofType(String.class).withValuesSeparatedBy(",");
         mavenRootsOption = argumentBuilder.apply("mavenRoots", "Maven root directories").withRequiredArg().ofType(String.class).withValuesSeparatedBy(",");
@@ -128,6 +132,7 @@ public class FMLServiceProvider implements ITransformationService
         targetMcVersion = option.value(mcOption);
         targetMcpVersion = option.value(mcpOption);
         targetMcpMappings = option.value(mappingsOption);
+        neoForgeGroup = option.value(groupOption);
     }
 
     @Override

--- a/loader/src/main/java/net/neoforged/fml/loading/VersionInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/VersionInfo.java
@@ -7,9 +7,9 @@ package net.neoforged.fml.loading;
 
 import java.util.Map;
 
-public record VersionInfo(String neoForgeVersion, String fmlVersion, String mcVersion, String neoFormVersion) {
+public record VersionInfo(String neoForgeVersion, String fmlVersion, String mcVersion, String neoFormVersion, String neoForgeGroup) {
     VersionInfo(Map<String, ?> arguments) {
-        this((String) arguments.get("neoForgeVersion"), (String) arguments.get("fmlVersion"), (String) arguments.get("mcVersion"), (String) arguments.get("neoFormVersion"));
+        this((String) arguments.get("neoForgeVersion"), (String) arguments.get("fmlVersion"), (String) arguments.get("mcVersion"), (String) arguments.get("neoFormVersion"), getNeoForgeGroup((String) arguments.get("neoForgeGroup")));
     }
 
     public String mcAndFmlVersion() {
@@ -18,5 +18,9 @@ public record VersionInfo(String neoForgeVersion, String fmlVersion, String mcVe
 
     public String mcAndNeoFormVersion() {
         return mcVersion + "-" + neoFormVersion;
+    }
+    
+    private static String getNeoForgeGroup(String neoForgeGroup) {
+        return neoForgeGroup == null ? "net.neoforged" : neoForgeGroup;
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/loading/targets/ForgeClientLaunchHandler.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/targets/ForgeClientLaunchHandler.java
@@ -17,8 +17,8 @@ public class ForgeClientLaunchHandler extends CommonClientLaunchHandler {
 
     @Override
     protected void processMCStream(VersionInfo versionInfo, Stream.Builder<Path> mc, Stream.Builder<List<Path>> mods) {
-        var forgepatches = LibraryFinder.findPathForMaven("net.neoforged", "neoforge", "", "client", versionInfo.neoForgeVersion());
-        var forgejar = LibraryFinder.findPathForMaven("net.neoforged", "neoforge", "", "universal", versionInfo.neoForgeVersion());
+        var forgepatches = LibraryFinder.findPathForMaven(versionInfo.neoForgeGroup(), "neoforge", "", "client", versionInfo.neoForgeVersion());
+        var forgejar = LibraryFinder.findPathForMaven(versionInfo.neoForgeGroup(), "neoforge", "", "universal", versionInfo.neoForgeVersion());
         mc.add(forgepatches);
         mods.add(List.of(forgejar));
     }

--- a/loader/src/main/java/net/neoforged/fml/loading/targets/ForgeServerLaunchHandler.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/targets/ForgeServerLaunchHandler.java
@@ -17,8 +17,8 @@ public class ForgeServerLaunchHandler extends CommonServerLaunchHandler {
 
     @Override
     protected void processMCStream(VersionInfo versionInfo, Stream.Builder<Path> mc, Stream.Builder<List<Path>> mods) {
-        var forgepatches = LibraryFinder.findPathForMaven("net.neoforged", "neoforge", "", "server", versionInfo.neoForgeVersion());
-        var forgejar = LibraryFinder.findPathForMaven("net.neoforged", "neoforge", "", "universal", versionInfo.neoForgeVersion());
+        var forgepatches = LibraryFinder.findPathForMaven(versionInfo.neoForgeGroup(), "neoforge", "", "server", versionInfo.neoForgeVersion());
+        var forgejar = LibraryFinder.findPathForMaven(versionInfo.neoForgeGroup(), "neoforge", "", "universal", versionInfo.neoForgeVersion());
         mc.add(forgepatches);
         mods.add(List.of(forgejar));
     }


### PR DESCRIPTION
I created this PR to add an argument ("--fml.neoForgeGroup") to modify the NeoForge artifact group. You don't need to add this argument to win_args and unix_args because when the argument is null automatically sets "net.neoforged".