### PR TITLE
Implement dependency-based (partial) ordering for parallel initialization tasks

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoader.java
@@ -225,7 +225,7 @@ public final class ModLoader {
                                     if (exception != null) {
                                         // If there was any exception, short circuit.
                                         // The exception will already be handled by `waitForFuture` since it comes from another mod.
-                                        LOGGER.error("Skipping {} future for mod {} because a dependency threw an exception.", name, modContainer.getModId());
+                                        LOGGER.debug("Skipping {} task for mod {} because a dependency threw an exception.", name, modContainer.getModId());
                                         progress.increment();
                                         // Throw a marker exception to make sure that dependencies of *this* task don't get executed.
                                         throw new DependentFutureFailedException();

--- a/loader/src/main/java/net/neoforged/fml/ModLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoader.java
@@ -204,7 +204,7 @@ public final class ModLoader {
         var progress = StartupNotificationManager.addProgressBar(name, modList.size());
         try {
             periodicTask.run();
-            Map<IModInfo, CompletableFuture<Void>> modFutures = new IdentityHashMap<>();
+            Map<IModInfo, CompletableFuture<Void>> modFutures = new IdentityHashMap<>(modList.size());
             var futureList = modList.getSortedMods().stream()
                     .map(modContainer -> {
                         // Collect futures for all dependencies first

--- a/loader/src/main/java/net/neoforged/fml/loading/LoadingModList.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/LoadingModList.java
@@ -23,6 +23,7 @@ import net.neoforged.fml.loading.moddiscovery.ModFile;
 import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.fml.loading.moddiscovery.ModInfo;
 import net.neoforged.fml.loading.modscan.BackgroundScanHandler;
+import net.neoforged.neoforgespi.language.IModInfo;
 
 /**
  * Master list of all mods <em>in the loading context. This class cannot refer outside the
@@ -32,10 +33,11 @@ public class LoadingModList {
     private static LoadingModList INSTANCE;
     private final List<ModFileInfo> modFiles;
     private final List<ModInfo> sortedList;
+    private final Map<ModInfo, List<ModInfo>> modDependencies;
     private final Map<String, ModFileInfo> fileById;
     private final List<ModLoadingIssue> modLoadingIssues;
 
-    private LoadingModList(final List<ModFile> modFiles, final List<ModInfo> sortedList) {
+    private LoadingModList(final List<ModFile> modFiles, final List<ModInfo> sortedList, Map<ModInfo, List<ModInfo>> modDependencies) {
         this.modFiles = modFiles.stream()
                 .map(ModFile::getModFileInfo)
                 .map(ModFileInfo.class::cast)
@@ -43,6 +45,7 @@ public class LoadingModList {
         this.sortedList = sortedList.stream()
                 .map(ModInfo.class::cast)
                 .collect(Collectors.toList());
+        this.modDependencies = modDependencies;
         this.fileById = this.modFiles.stream()
                 .map(ModFileInfo::getMods)
                 .flatMap(Collection::stream)
@@ -51,8 +54,8 @@ public class LoadingModList {
         this.modLoadingIssues = new ArrayList<>();
     }
 
-    public static LoadingModList of(List<ModFile> modFiles, List<ModInfo> sortedList, List<ModLoadingIssue> issues) {
-        INSTANCE = new LoadingModList(modFiles, sortedList);
+    public static LoadingModList of(List<ModFile> modFiles, List<ModInfo> sortedList, List<ModLoadingIssue> issues, Map<ModInfo, List<ModInfo>> modDependencies) {
+        INSTANCE = new LoadingModList(modFiles, sortedList, modDependencies);
         INSTANCE.modLoadingIssues.addAll(issues);
         return INSTANCE;
     }
@@ -152,6 +155,10 @@ public class LoadingModList {
 
     public List<ModInfo> getMods() {
         return this.sortedList;
+    }
+
+    public List<ModInfo> getDependencies(IModInfo mod) {
+        return this.modDependencies.getOrDefault(mod, List.of());
     }
 
     public boolean hasErrors() {

--- a/loader/src/main/java/net/neoforged/fml/loading/LoadingModList.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/LoadingModList.java
@@ -157,6 +157,13 @@ public class LoadingModList {
         return this.sortedList;
     }
 
+    /**
+     * Returns all direct loading dependencies of the given mod.
+     *
+     * <p>This means: all the mods that are directly specified to be loaded before the given mod,
+     * either because the given mod has an {@link IModInfo.Ordering#AFTER} constraint on the dependency,
+     * or because the dependency has a {@link IModInfo.Ordering#BEFORE} constraint on the given mod.
+     */
     public List<ModInfo> getDependencies(IModInfo mod) {
         return this.modDependencies.getOrDefault(mod, List.of());
     }


### PR DESCRIPTION
This PR allows mods to be constructed etc. _after_ their dependencies are. (Assuming `ordering="AFTER"` of course; otherwise the opposite happens). To do so, this PR does the following:
- Change mod ordering so that each mod inside a file is ordered independently from other mods (previously only files as a whole were ordered). This allows us to test this ordering in NeoForge, and it generally makes more sense given that dependencies are per-mod rather than per-file.
- Cache dependency information in adjacency list format in the `LoadingModList`.
- Do a bit of `CompletableFuture` manipulation to ensure that parallel tasks respect dependency "links". Mods with ordering constraints will respect the constraints, whereas "unrelated" mods will run in parallel.

Fixes https://github.com/neoforged/NeoForge/issues/540.