### PR TITLE
Allow FML translations to use the vanilla format specifier

### DIFF
--- a/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
+++ b/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
@@ -14,8 +14,8 @@ public class TranslationPatternsTest {
                 .isEqualTo("this is a translation b a");
    }
 
-   @Test
-   void testDoublePercent() {
+    @Test
+    void testDoublePercent() {
        Assertions.assertThat(FMLTranslations.parseFormat("%%")).isEqualTo("%");
-   }
+    }
 }

--- a/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
+++ b/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
@@ -1,0 +1,16 @@
+package net.neoforged.fml.test;
+
+import net.neoforged.fml.i18n.FMLTranslations;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class TranslationPatternsTest {
+    @Test
+    void testVanillaFormatSpecifiers() {
+        Assertions.assertThat(FMLTranslations.parseFormat("this is a translation %s %s", "a", "b"))
+                .isEqualTo("this is a translation a b");
+
+        Assertions.assertThat(FMLTranslations.parseFormat("this is a translation %2$s %1$s", "a", "b"))
+                .isEqualTo("this is a translation b a");
+    }
+}

--- a/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
+++ b/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
@@ -12,5 +12,10 @@ public class TranslationPatternsTest {
 
         Assertions.assertThat(FMLTranslations.parseFormat("this is a translation %2$s %1$s", "a", "b"))
                 .isEqualTo("this is a translation b a");
-    }
+   }
+
+   @Test
+   void testDoublePercent() {
+       Assertions.assertThat(FMLTranslations.parseFormat("%%")).isEqualTo("%");
+   }
 }

--- a/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
+++ b/loader/src/test/java/net/neoforged/fml/test/TranslationPatternsTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.fml.test;
 
 import net.neoforged.fml.i18n.FMLTranslations;
@@ -12,10 +17,10 @@ public class TranslationPatternsTest {
 
         Assertions.assertThat(FMLTranslations.parseFormat("this is a translation %2$s %1$s", "a", "b"))
                 .isEqualTo("this is a translation b a");
-   }
+    }
 
     @Test
     void testDoublePercent() {
-       Assertions.assertThat(FMLTranslations.parseFormat("%%")).isEqualTo("%");
+        Assertions.assertThat(FMLTranslations.parseFormat("%%")).isEqualTo("%");
     }
 }


### PR DESCRIPTION
`%s` and `%<nr>$s`