### PR TITLE
Safeguard against crashes if the PerformanceInfo fails to update

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
@@ -14,7 +14,7 @@ public class PerformanceInfo {
     private final OperatingSystemMXBean osBean;
     private final MemoryMXBean memoryBean;
     float memory;
-    private String text;
+    private String text = "";
 
     PerformanceInfo() {
         osBean = ManagementFactory.getPlatformMXBean(OperatingSystemMXBean.class);


### PR DESCRIPTION
We've seen a crash report by a modder for whom the `text` was null, leading to an NPE.

I'd assume this is due to the update method throwing before it gets to setting the text (candidates are a division by zero, or the JMX MBeans throwing for some unknown reason).