### PR TITLE
Fix Neoforge not being loaded in case of errors due to missing Jar Manifest

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/ModSorter.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/ModSorter.java
@@ -174,8 +174,9 @@ public class ModSorter {
     private void detectSystemMods(final Map<String, List<ModFile>> modFilesByFirstId) {
         // Capture system mods (ex. MC, Forge) here, so we can keep them for later
         final Set<String> systemMods = new HashSet<>();
-        // The minecraft mod is always a system mod
+        // The minecraft and neoforge mods are always system mods
         systemMods.add("minecraft");
+        systemMods.add("neoforge");
         // Find system mod files and scan them for system mods
         modFiles.stream()
                 .map(ModFile::getSecureJar)


### PR DESCRIPTION
This works around https://github.com/neoforged/NeoGradle/issues/174 by always making neoforge a system mod regardless of the Manifest not being read correctly.

This issue arose due to the Locator refactor, since previously the NeoForge mod-file was built from two JarContent objects nested within each other. The inner JarContent had no manifest since it tried reading it using a JarInputStream, while the outer JarContent did have a Manifest since it read it from the inner JarContent's root directory (via NIO).