### PR TITLE
Be more specific about @Mod initializer order

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/common/Mod.java
+++ b/loader/src/main/java/net/neoforged/fml/common/Mod.java
@@ -16,7 +16,8 @@ import net.neoforged.api.distmarker.Dist;
  * <p>
  * Any class found with this annotation applied will be loaded as a mod entrypoint for the mod with the given {@linkplain #value() ID}. <br>
  * A mod loaded with the {@code javafml} language loader may have multiple entrypoints, but it must have <strong>at least one</strong>.
- * However, a mod can have entrypoints for only one {@linkplain #dist() side}.
+ * Entrypoints for all {@link #dist}s are always run before entrypoints for a single {@link #dist}.
+ * An {@link #order} may be specified to order entrypoints within a given {@link #dist}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -36,8 +37,8 @@ public @interface Mod {
     Dist[] dist() default { Dist.CLIENT, Dist.DEDICATED_SERVER };
 
     /**
-     * The order in which to run entrypoints, when there are multiple. Entrypoints will be run from the lowest
-     * {@code order} value to the highest, within a given mod.
+     * The order in which to run entrypoints on a given side, when there are multiple. Entrypoints will be run from the
+     * lowest {@code order} value to the highest, within a given mod.
      */
     int order() default 0;
 }

--- a/loader/src/main/java/net/neoforged/fml/common/Mod.java
+++ b/loader/src/main/java/net/neoforged/fml/common/Mod.java
@@ -17,7 +17,6 @@ import net.neoforged.api.distmarker.Dist;
  * Any class found with this annotation applied will be loaded as a mod entrypoint for the mod with the given {@linkplain #value() ID}. <br>
  * A mod loaded with the {@code javafml} language loader may have multiple entrypoints, but it must have <strong>at least one</strong>.
  * Entrypoints for all {@link #dist}s are always run before entrypoints for a single {@link #dist}.
- * An {@link #order} may be specified to order entrypoints within a given {@link #dist}.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
@@ -35,10 +34,4 @@ public @interface Mod {
      * {@return the side to load this mod entrypoint on}
      */
     Dist[] dist() default { Dist.CLIENT, Dist.DEDICATED_SERVER };
-
-    /**
-     * The order in which to run entrypoints on a given side, when there are multiple. Entrypoints will be run from the
-     * lowest {@code order} value to the highest, within a given mod.
-     */
-    int order() default 0;
 }

--- a/loader/src/main/java/net/neoforged/fml/common/Mod.java
+++ b/loader/src/main/java/net/neoforged/fml/common/Mod.java
@@ -34,4 +34,10 @@ public @interface Mod {
      * {@return the side to load this mod entrypoint on}
      */
     Dist[] dist() default { Dist.CLIENT, Dist.DEDICATED_SERVER };
+
+    /**
+     * The order in which to run entrypoints, when there are multiple. Entrypoints will be run from the lowest
+     * {@code order} value to the highest, within a given mod.
+     */
+    int order() default 0;
 }

--- a/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProvider.java
@@ -7,7 +7,9 @@ package net.neoforged.fml.javafmlmod;
 
 import java.lang.annotation.ElementType;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.ModLoadingIssue;
@@ -30,6 +32,7 @@ public class FMLJavaModLanguageProvider extends BuiltInLanguageLoader {
         final var modClasses = modFileScanResults.getAnnotatedBy(Mod.class, ElementType.TYPE)
                 .filter(data -> data.annotationData().get("value").equals(info.getModId()))
                 .filter(ad -> AutomaticEventSubscriber.getSides(ad.annotationData().get("dist")).contains(FMLLoader.getDist()))
+                .sorted(Comparator.comparingInt(ad -> Objects.requireNonNullElse((Integer)ad.annotationData().get("order"), 0)))
                 .map(ad -> ad.clazz().getClassName())
                 .toList();
         return new FMLModContainer(info, modClasses, modFileScanResults, layer);

--- a/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProvider.java
@@ -32,7 +32,11 @@ public class FMLJavaModLanguageProvider extends BuiltInLanguageLoader {
         final var modClasses = modFileScanResults.getAnnotatedBy(Mod.class, ElementType.TYPE)
                 .filter(data -> data.annotationData().get("value").equals(info.getModId()))
                 .filter(ad -> AutomaticEventSubscriber.getSides(ad.annotationData().get("dist")).contains(FMLLoader.getDist()))
-                .sorted(Comparator.comparingInt(ad -> Objects.requireNonNullElse((Integer)ad.annotationData().get("order"), 0)))
+                .sorted(Comparator
+                    .<ModFileScanData.AnnotationData>comparingInt(ad -> AutomaticEventSubscriber.getSides(ad.annotationData().get("dist")).size())
+                    .reversed()
+                    .thenComparingInt(ad -> Objects.requireNonNullElse((Integer)ad.annotationData().get("order"), 0))
+                )
                 .map(ad -> ad.clazz().getClassName())
                 .toList();
         return new FMLModContainer(info, modClasses, modFileScanResults, layer);

--- a/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProvider.java
@@ -9,7 +9,6 @@ import java.lang.annotation.ElementType;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.ModLoadingIssue;
@@ -32,11 +31,7 @@ public class FMLJavaModLanguageProvider extends BuiltInLanguageLoader {
         final var modClasses = modFileScanResults.getAnnotatedBy(Mod.class, ElementType.TYPE)
                 .filter(data -> data.annotationData().get("value").equals(info.getModId()))
                 .filter(ad -> AutomaticEventSubscriber.getSides(ad.annotationData().get("dist")).contains(FMLLoader.getDist()))
-                .sorted(Comparator
-                    .<ModFileScanData.AnnotationData>comparingInt(ad -> AutomaticEventSubscriber.getSides(ad.annotationData().get("dist")).size())
-                    .reversed()
-                    .thenComparingInt(ad -> Objects.requireNonNullElse((Integer)ad.annotationData().get("order"), 0))
-                )
+                .sorted(Comparator.comparingInt(ad -> -AutomaticEventSubscriber.getSides(ad.annotationData().get("dist")).size()))
                 .map(ad -> ad.clazz().getClassName())
                 .toList();
         return new FMLModContainer(info, modClasses, modFileScanResults, layer);

--- a/loader/src/test/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProviderTest.java
+++ b/loader/src/test/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProviderTest.java
@@ -116,7 +116,7 @@ public class FMLJavaModLanguageProviderTest extends LauncherTest {
         var testJar = installation.writeModJar("test.jar", SimulatedInstallation.createModsToml("testmod", "1.0"));
         try (var compiler = RuntimeCompiler.create(testJar)) {
             compiler.builder()
-                .addClass("testmod.EntryPoint", """
+                    .addClass("testmod.EntryPoint", """
                             @net.neoforged.fml.common.Mod("testmod")
                             public class EntryPoint {
                                 public EntryPoint() {
@@ -124,7 +124,7 @@ public class FMLJavaModLanguageProviderTest extends LauncherTest {
                                 }
                             }
                             """)
-                .addClass("testmod.ClientEntryPoint", """
+                    .addClass("testmod.ClientEntryPoint", """
                             @net.neoforged.fml.common.Mod(value = "testmod", dist = net.neoforged.api.distmarker.Dist.CLIENT)
                             public class ClientEntryPoint {
                                 public ClientEntryPoint() {
@@ -132,7 +132,7 @@ public class FMLJavaModLanguageProviderTest extends LauncherTest {
                                 }
                             }
                             """)
-                .compile();
+                    .compile();
         }
 
         var result = launch("forgeclient");

--- a/loader/src/test/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProviderTest.java
+++ b/loader/src/test/java/net/neoforged/fml/javafmlmod/FMLJavaModLanguageProviderTest.java
@@ -138,8 +138,6 @@ public class FMLJavaModLanguageProviderTest extends LauncherTest {
         var result = launch("forgeclient");
         loadMods(result);
 
-        ModLoader.dispatchParallelEvent("test", Runnable::run, Runnable::run, () -> {}, FMLClientSetupEvent::new);
-
         assertThat(MESSAGES).isEqualTo(List.of("common", "client"));
     }
 


### PR DESCRIPTION
Common initializers are now always run before sided.

In this example, `MyMod` will always be run before `MyModClient`.
```java
@Mod(MyMod.MOD_ID)
class MyMod {
    public static final String MOD_ID = "mymod";
}

@Mod(value = MyMod.MOD_ID, dist = Dist.CLIENT)
class MyModClient {
}
```