### PR TITLE
Remove service provider declarations that don't exist anymore

### DIFF
--- a/loader/src/main/resources/META-INF/services/cpw.mods.modlauncher.api.INameMappingService
+++ b/loader/src/main/resources/META-INF/services/cpw.mods.modlauncher.api.INameMappingService
@@ -1,1 +1,0 @@
-net.neoforged.fml.loading.MCPNamingService

--- a/loader/src/main/resources/META-INF/services/net.neoforged.fml.IModStateProvider
+++ b/loader/src/main/resources/META-INF/services/net.neoforged.fml.IModStateProvider
@@ -1,1 +1,0 @@
-net.neoforged.fml.core.ModStateProvider


### PR DESCRIPTION
They cause a startup exception when booting with FML on the module path.