### PR TITLE
Respect the foreground color in more places in the early display

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/RenderElement.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/RenderElement.java
@@ -179,7 +179,7 @@ public class RenderElement {
     private static Renderer barRenderer(int cnt, int alpha, SimpleFont font, ProgressMeter pm, DisplayContext context) {
         var barSpacing = font.lineSpacing() - font.descent() + BAR_HEIGHT;
         var y = 250 * context.scale() + cnt * barSpacing;
-        var colour = context.colourScheme.foreground().packedint(alpha); //(alpha << 24) | 0xFFFFFF;
+        var colour = context.colourScheme.foreground().packedint(alpha);
         Renderer bar;
         if (pm.steps() == 0) {
             bar = progressBar(ctx -> new int[] { (ctx.scaledWidth() - BAR_WIDTH * ctx.scale()) / 2, y + font.lineSpacing() - font.descent(), BAR_WIDTH * ctx.scale() }, f -> colour, frame -> indeterminateBar(frame, cnt == 0));


### PR DESCRIPTION
For some reason, the progress bar outline respects the foreground color, but the actual progress doesn't.
The startup log messages also don't respect the foreground color, while the NeoForge version overlay does.
As well as the Mojang Studios logo