### PR TITLE
Improve hasErrors implementations

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoader.java
@@ -392,7 +392,7 @@ public final class ModLoader {
      *         If you are running in a Mixin before mod loading has actually started, check {@link LoadingModList#hasErrors()} instead.
      */
     public static boolean hasErrors() {
-        return loadingIssues.stream().anyMatch(issue -> issue.severity() == ModLoadingIssue.Severity.ERROR);
+        return !loadingIssues.isEmpty() && loadingIssues.stream().anyMatch(issue -> issue.severity() == ModLoadingIssue.Severity.ERROR);
     }
 
     @ApiStatus.Internal

--- a/loader/src/main/java/net/neoforged/fml/loading/LoadingModList.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/LoadingModList.java
@@ -170,7 +170,7 @@ public class LoadingModList {
     }
 
     public boolean hasErrors() {
-        return modLoadingIssues.stream().noneMatch(issue -> issue.severity() == ModLoadingIssue.Severity.ERROR);
+        return !modLoadingIssues.isEmpty() && modLoadingIssues.stream().anyMatch(issue -> issue.severity() == ModLoadingIssue.Severity.ERROR);
     }
 
     public List<ModLoadingIssue> getModLoadingIssues() {


### PR DESCRIPTION
This PR fixes an issue where `LoadingModList.hasErrors` incorrectly returns `true` if there are actually no loading errors. The original logic of this method appears to be backwards, it returns `true` if none of the issues have a severity of ERROR.

Additionally, I made both `LoadingModList.hasErrors()` and `ModLoader.hasErrors()` check that the list of issues is non-empty before bothering to create a stream. This avoids unnecessary stream allocations in hot code in the very common case of there being no warnings or errors, and is trivial enough that it's harmless to add.