### PR TITLE
Don't add modFolders as mods directly. Rather use them to group existing classpath entries

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/locators/UserdevLocator.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/locators/UserdevLocator.java
@@ -5,12 +5,6 @@
 
 package net.neoforged.fml.loading.moddiscovery.locators;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import net.neoforged.fml.loading.moddiscovery.readers.JarModsDotTomlModFileReader;
 import net.neoforged.fml.util.DevEnvUtils;
 import net.neoforged.neoforgespi.ILaunchContext;
@@ -18,8 +12,22 @@ import net.neoforged.neoforgespi.locating.IDiscoveryPipeline;
 import net.neoforged.neoforgespi.locating.IModFileCandidateLocator;
 import net.neoforged.neoforgespi.locating.IncompatibleFileReporting;
 import net.neoforged.neoforgespi.locating.ModFileDiscoveryAttributes;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class UserdevLocator implements IModFileCandidateLocator {
+    private static final Logger LOGGER = LogManager.getLogger();
+
     private final Map<String, List<Path>> modFolders;
 
     public UserdevLocator(Map<String, List<Path>> modFolders) {
@@ -28,10 +36,29 @@ public class UserdevLocator implements IModFileCandidateLocator {
 
     @Override
     public void findCandidates(ILaunchContext context, IDiscoveryPipeline pipeline) {
+
+        // Index the JVM classpath
+        var entriesOnClasspath = new HashSet<>();
+        for (String entry : System.getProperty("java.class.path").split(Pattern.quote(File.pathSeparator))) {
+            try {
+                var path = Paths.get(entry);
+                entriesOnClasspath.add(path);
+            } catch (Exception ignored) {
+            }
+        }
+
         var claimed = modFolders.values().stream().flatMap(List::stream).collect(Collectors.toCollection(HashSet::new));
 
-        for (var modFolderGroup : modFolders.values()) {
-            pipeline.addPath(modFolderGroup, ModFileDiscoveryAttributes.DEFAULT, IncompatibleFileReporting.ERROR);
+        for (var entry : modFolders.entrySet()) {
+            var key = entry.getKey();
+            var groupedFolders = entry.getValue();
+            var existingFolders = groupedFolders.stream().filter(entriesOnClasspath::contains).toList();
+            if (existingFolders.isEmpty()) {
+                LOGGER.warn("Mod folder group {} matches no folders on the classpath", key);
+                continue;
+            }
+
+            pipeline.addPath(existingFolders, ModFileDiscoveryAttributes.DEFAULT, IncompatibleFileReporting.ERROR);
         }
 
         var fromClasspath = new ArrayList<Path>();


### PR DESCRIPTION
**Note:** Breaking change, since users might currently set Source Sets in NG which are ultimately not on the classpath (this leads to debugging issues in IJ, but it might still be the case). We might want to hide this behind a flag, or use a different system property for it.

This passes control over which moddev mods get loaded to the classpath used when setting up the JVM, which will usually be Gradle or an IDE. This setup allows Gradle plugins to always pass all "potential" folders where compiled mod classes could be, and let FML sort out which ones are actually present on the classpath. Example: add the IntelliJ and Gradle Folders for IJ runs since we cannot know which build-tool is used by IJ. (same for Eclipse)