### PR TITLE
Config cleanup, part 2

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModContainer.java
+++ b/loader/src/main/java/net/neoforged/fml/ModContainer.java
@@ -7,7 +7,6 @@ package net.neoforged.fml;
 
 import static net.neoforged.fml.Logging.LOADING;
 
-import java.util.EnumMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -21,7 +20,6 @@ import net.neoforged.fml.config.IConfigSpec;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.fml.event.lifecycle.FMLConstructModEvent;
-import net.neoforged.fml.loading.FMLPaths;
 import net.neoforged.neoforgespi.language.IModInfo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -48,7 +46,6 @@ public abstract class ModContainer {
     protected final String namespace;
     protected final IModInfo modInfo;
     protected final Map<Class<? extends IExtensionPoint>, Supplier<?>> extensionPoints = new IdentityHashMap<>();
-    protected final EnumMap<ModConfig.Type, ModConfig> configs = new EnumMap<>(ModConfig.Type.class);
 
     public ModContainer(IModInfo info) {
         this.modId = info.getModId();
@@ -95,14 +92,6 @@ public abstract class ModContainer {
         extensionPoints.put(point, extension);
     }
 
-    private void addConfig(final ModConfig modConfig) {
-        configs.put(modConfig.getType(), modConfig);
-
-        if (modConfig.getType() == ModConfig.Type.STARTUP) {
-            ConfigTracker.INSTANCE.openConfig(modConfig, FMLPaths.CONFIGDIR.get(), null);
-        }
-    }
-
     /**
      * Adds a {@link ModConfig} with the given type and spec. An empty config spec will be ignored and a debug line will
      * be logged.
@@ -117,7 +106,7 @@ public abstract class ModContainer {
             return;
         }
 
-        addConfig(ConfigTracker.INSTANCE.registerConfig(type, configSpec, this));
+        ConfigTracker.INSTANCE.registerConfig(type, configSpec, this);
     }
 
     /**
@@ -134,7 +123,7 @@ public abstract class ModContainer {
             return;
         }
 
-        addConfig(ConfigTracker.INSTANCE.registerConfig(type, configSpec, this, fileName));
+        ConfigTracker.INSTANCE.registerConfig(type, configSpec, this, fileName);
     }
 
     /**

--- a/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
@@ -87,6 +87,11 @@ public class ConfigTracker {
         var lock = locksByMod.computeIfAbsent(container.getModId(), m -> new ReentrantLock());
         var modConfig = new ModConfig(type, spec, container, fileName, lock);
         trackConfig(modConfig);
+
+        if (modConfig.getType() == ModConfig.Type.STARTUP) {
+            openConfig(modConfig, FMLPaths.CONFIGDIR.get(), null);
+        }
+
         return modConfig;
     }
 
@@ -120,7 +125,7 @@ public class ConfigTracker {
         this.configSets.get(type).forEach(ConfigTracker::closeConfig);
     }
 
-    public static void openConfig(ModConfig config, Path configBasePath, @Nullable Path configOverrideBasePath) {
+    static void openConfig(ModConfig config, Path configBasePath, @Nullable Path configOverrideBasePath) {
         LOGGER.trace(CONFIG, "Loading config file type {} at {} for {}", config.getType(), config.getFileName(), config.getModId());
         if (config.loadedConfig != null) {
             LOGGER.warn("Opening a config that was already loaded with value {} at path {}", config.loadedConfig, config.getFileName());

--- a/loader/src/main/java/net/neoforged/fml/config/ConfigWatcher.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ConfigWatcher.java
@@ -5,8 +5,8 @@
 
 package net.neoforged.fml.config;
 
-import com.electronwill.nightconfig.core.file.CommentedFileConfig;
 import com.mojang.logging.LogUtils;
+import java.nio.file.Path;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import org.slf4j.Logger;
 
@@ -14,12 +14,12 @@ class ConfigWatcher implements Runnable {
     private static final Logger LOGGER = LogUtils.getLogger();
 
     private final ModConfig modConfig;
-    private final CommentedFileConfig commentedFileConfig;
+    private final Path path;
     private final ClassLoader realClassLoader;
 
-    ConfigWatcher(ModConfig modConfig, CommentedFileConfig commentedFileConfig, ClassLoader classLoader) {
+    ConfigWatcher(ModConfig modConfig, Path path, ClassLoader classLoader) {
         this.modConfig = modConfig;
-        this.commentedFileConfig = commentedFileConfig;
+        this.path = path;
         this.realClassLoader = classLoader;
     }
 
@@ -32,11 +32,7 @@ class ConfigWatcher implements Runnable {
             modConfig.lock.lock();
             try {
                 LOGGER.debug(ConfigTracker.CONFIG, "Config file {} changed, re-loading", modConfig.getFileName());
-                if (this.modConfig.config != this.commentedFileConfig) {
-                    LOGGER.warn(ConfigTracker.CONFIG, "Config file {} has a mismatched loaded config. Expected {} but was {}.", modConfig.getFileName(), commentedFileConfig, modConfig.config);
-                }
-                ConfigTracker.loadConfig(this.modConfig, this.commentedFileConfig);
-                this.modConfig.postConfigEvent(ModConfigEvent.Reloading::new);
+                ConfigTracker.loadConfig(this.modConfig, this.path, ModConfigEvent.Reloading::new);
             } finally {
                 modConfig.lock.unlock();
             }

--- a/loader/src/main/java/net/neoforged/fml/config/IConfigSpec.java
+++ b/loader/src/main/java/net/neoforged/fml/config/IConfigSpec.java
@@ -18,8 +18,7 @@ import org.jetbrains.annotations.Nullable;
  * <h3>Thread-safety</h3>
  * <p>The {@link Config} objects themselves are thread-safe, but mod config code should not be assumed to be thread-safe in general.
  * FML will guard event dispatches behind a lock when necessary.
- * A spec can safely mutate {@code Config} objects, but should let FML fire events,
- * for example using {@link ModConfig#onConfigChanged()}.
+ * A spec can safely mutate {@code Config} objects, but should let FML fire events and saving the file by calling {@link ILoadedConfig#save()}.
  */
 public interface IConfigSpec {
     /**
@@ -53,5 +52,20 @@ public interface IConfigSpec {
      * This is called on loading and on reloading.
      * The config is guaranteed to be valid according to {@link #isCorrect}.
      */
-    void acceptConfig(@Nullable CommentedConfig config);
+    void acceptConfig(@Nullable ILoadedConfig config);
+
+    sealed interface ILoadedConfig permits LoadedConfig {
+        /**
+         * Accesses the current config.
+         *
+         * <p>The config locks internally, and is therefore safe to
+         * read/write across multiple threads without additional synchronization.
+         */
+        CommentedConfig config();
+
+        /**
+         * Saves the current value of the {@link #config} and dispatches a config reloading event.
+         */
+        void save();
+    }
 }

--- a/loader/src/main/java/net/neoforged/fml/config/LoadedConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/LoadedConfig.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.fml.config;
+
+import com.electronwill.nightconfig.core.CommentedConfig;
+import java.nio.file.Path;
+import net.neoforged.fml.event.config.ModConfigEvent;
+import org.jetbrains.annotations.Nullable;
+
+record LoadedConfig(CommentedConfig config, @Nullable Path path, ModConfig modConfig) implements IConfigSpec.ILoadedConfig {
+    @Override
+    public void save() {
+        if (path != null) {
+            ConfigTracker.writeConfig(path, config);
+        }
+        modConfig.lock.lock();
+        try {
+            modConfig.container.acceptEvent(new ModConfigEvent.Reloading(modConfig));
+        } finally {
+            modConfig.lock.unlock();
+        }
+    }
+}

--- a/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
+++ b/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
@@ -14,6 +14,7 @@ import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.loading.FMLConfig;
 import net.neoforged.fml.loading.FMLPaths;
 import org.assertj.core.api.Assertions;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -218,8 +219,8 @@ public class ConfigTrackerTest {
         }
 
         @Override
-        public void acceptConfig(CommentedConfig config) {
-            loadedValue = config.getInt("configEntry");
+        public void acceptConfig(@Nullable ILoadedConfig config) {
+            loadedValue = config == null ? 4 : config.config().getInt("configEntry");
         }
     }
 }


### PR DESCRIPTION
Follow-up to #172.

- Stop using `FileConfig`, and instead read/write files manually.
- Pass an `ILoadedConfig` to the `IConfigSpec` so it has a backreference that can be used to save the file and fire events after modification.
- Remove unused config tracking inside the `ModContainer`s. The configs are already accessible via `ModConfigs`.