### PR TITLE
Find more intuitive orderings when there are multiple possible toposorts

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/toposort/TopologicalSort.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/toposort/TopologicalSort.java
@@ -84,15 +84,14 @@ public final class TopologicalSort<T> {
     private void resolveSubgraph(List<T> nodes) {
         while (!nodes.isEmpty()) {
             var min = removeMin(nodes);
-            if (!taken.contains(min)) {
-                // Process all dependencies of `min`
-                var subGraph = new ArrayList<T>();
-                collectChildren(min, subGraph);
-                resolveSubgraph(subGraph);
-                // Add `min`
-                result.add(min);
-                taken.add(min);
-            }
+            // Process all dependencies of `min`
+            var subGraph = new ArrayList<T>();
+            collectChildren(min, subGraph);
+            resolveSubgraph(subGraph);
+            nodes.removeIf(taken::contains);
+            // Add `min`
+            result.add(min);
+            taken.add(min);
         }
     }
 

--- a/loader/src/test/java/net/neoforged/fml/TopologicalSortTest.java
+++ b/loader/src/test/java/net/neoforged/fml/TopologicalSortTest.java
@@ -1,0 +1,42 @@
+package net.neoforged.fml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.graph.ElementOrder;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import java.util.Comparator;
+import net.neoforged.fml.loading.toposort.CyclePresentException;
+import net.neoforged.fml.loading.toposort.TopologicalSort;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("UnstableApiUsage") // guava graph is @Beta
+public class TopologicalSortTest {
+    @Test
+    public void testDefaultOrdering() {
+        MutableGraph<Integer> g = GraphBuilder.directed().nodeOrder(ElementOrder.insertion()).build();
+        g.putEdge(5, 0);
+        g.putEdge(5, 4);
+        g.putEdge(0, 1);
+        g.putEdge(1, 2);
+        g.putEdge(0, 4);
+        g.addNode(3);
+
+        var sorted = TopologicalSort.topologicalSort(g, Comparator.naturalOrder());
+        assertThat(sorted)
+                .containsExactly(5, 0, 1, 2, 3, 4);
+    }
+
+    @Test
+    public void testCycle() {
+        MutableGraph<Integer> g = GraphBuilder.directed().nodeOrder(ElementOrder.insertion()).build();
+        g.putEdge(0, 1);
+        g.putEdge(1, 3);
+        g.putEdge(3, 0);
+        g.addNode(2);
+
+        assertThatThrownBy(() -> TopologicalSort.topologicalSort(g, Comparator.naturalOrder()))
+                .isInstanceOf(CyclePresentException.class);
+    }
+}

--- a/loader/src/test/java/net/neoforged/fml/TopologicalSortTest.java
+++ b/loader/src/test/java/net/neoforged/fml/TopologicalSortTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.fml;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
The toposort will now try to get the "smallest" element as early into the output as possible. (The previous behavior was finding the lexicographically smallest toposort, which is not the same).

Here is an example. For the following graph:
![image](https://github.com/user-attachments/assets/5ca6cb82-e393-489b-84cb-a48029b49955)

The previous toposort would yield `3 5 0 1 2 4`. The new toposort yields `5 0 1 2 3 4`. Intuitively, we try to get the `0` as early as possible into the result.

This does change the complexity of the toposort from linear to quadratic. For our use cases (mod sorting, creative tab sorting, resource reload listener sorting), that should still be fast enough.

This PR also adds basic tests.