### PR TITLE
Fix NetworkedEnum annotation retention

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/common/asm/enumextension/NetworkedEnum.java
+++ b/loader/src/main/java/net/neoforged/fml/common/asm/enumextension/NetworkedEnum.java
@@ -6,6 +6,8 @@
 package net.neoforged.fml.common.asm.enumextension;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
@@ -14,6 +16,7 @@ import java.lang.annotation.Target;
  * @see ExtensionInfo
  */
 @Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface NetworkedEnum {
     NetworkCheck value();
 


### PR DESCRIPTION
This PR fixes the retention of the `NetworkCheck` annotation to allow the annotation to be read reflectively by `ExtensionInfo.nonExtended()`.