### PR TITLE
Add a method to validate the config spec

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
@@ -87,6 +87,8 @@ public class ConfigTracker {
     public ModConfig registerConfig(ModConfig.Type type, IConfigSpec spec, ModContainer container, String fileName) {
         var lock = locksByMod.computeIfAbsent(container.getModId(), m -> new ReentrantLock());
         var modConfig = new ModConfig(type, spec, container, fileName, lock);
+        spec.validateSpec(modConfig);
+
         trackConfig(modConfig);
 
         if (modConfig.getType() == ModConfig.Type.STARTUP) {

--- a/loader/src/main/java/net/neoforged/fml/config/IConfigSpec.java
+++ b/loader/src/main/java/net/neoforged/fml/config/IConfigSpec.java
@@ -27,6 +27,13 @@ public interface IConfigSpec {
     boolean isEmpty();
 
     /**
+     * Validate this specification in the context of the given {@code config}.
+     *
+     * @param config the configuration this spec is used by
+     */
+    void validateSpec(ModConfig config);
+
+    /**
      * Checks that a config is correct.
      * If this function returns {@code false},
      * a backup is made (except for initial creation) then the config is fed through {@link #correct}.

--- a/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
+++ b/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
@@ -205,9 +205,7 @@ public class ConfigTrackerTest {
         }
 
         @Override
-        public void validateSpec(ModConfig config) {
-
-        }
+        public void validateSpec(ModConfig config) {}
 
         @Override
         public boolean isCorrect(UnmodifiableCommentedConfig config) {

--- a/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
+++ b/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
@@ -171,6 +171,18 @@ public class ConfigTrackerTest {
         });
     }
 
+    @Test
+    void testValidation() {
+        var spec = new SimpleConfigSpec() {
+            @Override
+            public void validateSpec(ModConfig config) {
+                throw new IllegalArgumentException("Config is bad.");
+            }
+        };
+        Assertions.assertThatIllegalArgumentException()
+                .isThrownBy(() -> configTracker.registerConfig(ModConfig.Type.COMMON, spec, modContainer, "test.toml"));
+    }
+
     private void waitUntil(Runnable assertion) throws InterruptedException {
         for (int i = 0; i < 1000; ++i) {
             try {
@@ -190,6 +202,11 @@ public class ConfigTrackerTest {
         @Override
         public boolean isEmpty() {
             return false;
+        }
+
+        @Override
+        public void validateSpec(ModConfig config) {
+
         }
 
         @Override


### PR DESCRIPTION
Add a `IConfigSpec#validateSpec` method to validate the specification in the context of a mod config, i.e. to check if a value restart type is valid for a given config type.