### PR TITLE
Add simple getter for configs by mod and the loaded configs

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.fml.config;
 
+import com.electronwill.nightconfig.core.CommentedConfig;
 import java.nio.file.Path;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -49,6 +50,15 @@ public final class ModConfig {
 
     public String getModId() {
         return container.getModId();
+    }
+
+    /**
+     * Retrieve the currently loaded config, for direct manipulation of the underlying {@link CommentedConfig}.
+     * Note that the config will change on reloads, and will be {@code null} when the config is not loaded.
+     */
+    @Nullable
+    public IConfigSpec.ILoadedConfig getLoadedConfig() {
+        return loadedConfig;
     }
 
     // TODO: remove from public API?

--- a/loader/src/main/java/net/neoforged/fml/config/ModConfigs.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfigs.java
@@ -17,6 +17,10 @@ import net.neoforged.fml.ModContainer;
  * Configs are registered via {@link ModContainer#registerConfig(ModConfig.Type, IConfigSpec)}.
  */
 public final class ModConfigs {
+    public static List<ModConfig> getModConfigs(String modId) {
+        return List.copyOf(ConfigTracker.INSTANCE.configsByMod.getOrDefault(modId, List.of()));
+    }
+
     public static List<String> getConfigFileNames(String modId, ModConfig.Type type) {
         var config = ConfigTracker.INSTANCE.configsByMod.getOrDefault(modId, List.of());
         synchronized (config) { // Synchronized list: requires explicit synchronization for stream

--- a/loader/src/main/java/net/neoforged/fml/config/ModConfigs.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfigs.java
@@ -18,7 +18,7 @@ import net.neoforged.fml.ModContainer;
  */
 public final class ModConfigs {
     public static List<ModConfig> getModConfigs(String modId) {
-        return List.copyOf(ConfigTracker.INSTANCE.configsByMod.getOrDefault(modId, List.of()));
+        return Collections.unmodifiableList(ConfigTracker.INSTANCE.configsByMod.getOrDefault(modId, List.of()));
     }
 
     public static List<String> getConfigFileNames(String modId, ModConfig.Type type) {


### PR DESCRIPTION
Quite simple and useful, especially for alternative config screen implementations that have a different strategy. Requested by @Speiger in https://github.com/neoforged/NeoForge/issues/1336.

Fixes https://github.com/neoforged/NeoForge/issues/1336.