### PR TITLE
Support ordering of dependency locators

### DIFF
--- a/loader/src/main/java/net/neoforged/neoforgespi/locating/IDependencyLocator.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/locating/IDependencyLocator.java
@@ -11,7 +11,7 @@ import java.util.List;
  * Loaded as a ServiceLoader. Takes mechanisms for locating candidate "mod-dependencies".
  * and transforms them into {@link IModFile} objects.
  */
-public interface IDependencyLocator {
+public interface IDependencyLocator extends IOrderedProvider {
     /**
      * Invoked to find all mod dependencies that this dependency locator can find.
      * It is not guaranteed that all these are loaded into the runtime,


### PR DESCRIPTION
Adds support for ordering dependency locators. This is useful for mods that rely on information about previously located mods in the scanning process.