### PR TITLE
Add infrastructure to sync server config changes to connected clients

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/Bindings.java
+++ b/loader/src/main/java/net/neoforged/fml/Bindings.java
@@ -7,8 +7,11 @@ package net.neoforged.fml;
 
 import java.util.ServiceLoader;
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.config.IConfigSpec;
+import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.loading.FMLLoader;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public class Bindings {
@@ -25,5 +28,9 @@ public class Bindings {
 
     public static IEventBus getGameBus() {
         return provider.getGameBus();
+    }
+
+    public static void fireConfigChanged(ModConfig modConfig, @Nullable IConfigSpec.ILoadedConfig loadedConfig) {
+        provider.onConfigChanged(modConfig, loadedConfig);
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/IBindingsProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/IBindingsProvider.java
@@ -6,9 +6,18 @@
 package net.neoforged.fml;
 
 import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.config.IConfigSpec;
+import net.neoforged.fml.config.ModConfig;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public interface IBindingsProvider {
     IEventBus getGameBus();
+
+    /**
+     * Invoked when a config changed or might have changed, but not necessarily when a config is loaded.
+     * This method may be called from any thread, at any time.
+     */
+    void onConfigChanged(ModConfig modConfig, @Nullable IConfigSpec.ILoadedConfig loadedConfig);
 }

--- a/loader/src/main/java/net/neoforged/fml/config/LoadedConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/LoadedConfig.java
@@ -7,6 +7,7 @@ package net.neoforged.fml.config;
 
 import com.electronwill.nightconfig.core.CommentedConfig;
 import java.nio.file.Path;
+import net.neoforged.fml.Bindings;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import org.jetbrains.annotations.Nullable;
 
@@ -22,5 +23,6 @@ record LoadedConfig(CommentedConfig config, @Nullable Path path, ModConfig modCo
         } finally {
             modConfig.lock.unlock();
         }
+        Bindings.fireConfigChanged(modConfig, this);
     }
 }

--- a/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import net.neoforged.fml.Bindings;
 import net.neoforged.fml.ModContainer;
 import net.neoforged.fml.event.config.ModConfigEvent;
 import net.neoforged.fml.loading.StringUtils;
@@ -80,6 +81,8 @@ public final class ModConfig {
         } finally {
             lock.unlock();
         }
+
+        Bindings.fireConfigChanged(this, loadedConfig);
     }
 
     public enum Type {


### PR DESCRIPTION
What the title says. Combined with [NEOFORGE PR], all changes to server configs (because of the file watcher or a direct `.set/.save` call) are now synced to connected clients.