### PR TITLE
Undo bump of AccessTransformers to 11.0.1 (back to 10.0.1 for now)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ test_neoforge_version=21.0.163
 test_minecraft_version=1.21
 
 mergetool_version=2.0.0
-accesstransformers_version=11.0.1
+accesstransformers_version=10.0.1
 coremods_version=7.0.3
 eventbus_version=8.0.1
 modlauncher_version=11.0.3


### PR DESCRIPTION
#177 bumped the AT dependency to major version 11, which removes the ANTLR dependency. This is a good thing, however it is also a breaking change that should be kept for the next BC cycle.