### PR TITLE
Clarify startup screen's memory data and remove offheap text

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
@@ -9,7 +9,6 @@ import com.sun.management.OperatingSystemMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
-import net.neoforged.fml.loading.FMLLoader;
 
 public class PerformanceInfo {
     private final OperatingSystemMXBean osBean;
@@ -33,11 +32,7 @@ public class PerformanceInfo {
             cpuText = String.format("CPU: %.1f%%", cpuLoad * 100f);
         }
 
-        if (FMLLoader.isProduction()) {
-            text = String.format("Memory: %d/%d MB (%.1f%%)  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, cpuText);
-        } else {
-            text = String.format("Memory: %d/%d MB (%.1f%%) OffHeap: %d MB  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20, cpuText);
-        }
+        text = String.format("Memory: %d/%d MB (%.1f%%)  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, cpuText);
     }
 
     String text() {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
@@ -9,6 +9,7 @@ import com.sun.management.OperatingSystemMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.MemoryUsage;
+import net.neoforged.fml.loading.FMLLoader;
 
 public class PerformanceInfo {
     private final OperatingSystemMXBean osBean;
@@ -32,7 +33,11 @@ public class PerformanceInfo {
             cpuText = String.format("CPU: %.1f%%", cpuLoad * 100f);
         }
 
-        text = String.format("Memory: %d/%d MB (%.1f%%)  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, cpuText);
+        if (FMLLoader.isProduction()) {
+            text = String.format("Memory: %d/%d MB (%.1f%%)  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, cpuText);
+        } else {
+            text = String.format("Memory: %d/%d MB (%.1f%%) OffHeap: %d MB  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20, cpuText);
+        }
     }
 
     String text() {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/PerformanceInfo.java
@@ -32,7 +32,7 @@ public class PerformanceInfo {
             cpuText = String.format("CPU: %.1f%%", cpuLoad * 100f);
         }
 
-        text = String.format("Heap: %d/%d MB (%.1f%%) OffHeap: %d MB  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, memoryBean.getNonHeapMemoryUsage().getUsed() >> 20, cpuText);
+        text = String.format("Memory: %d/%d MB (%.1f%%)  %s", heapusage.getUsed() >> 20, heapusage.getMax() >> 20, memory * 100.0, cpuText);
     }
 
     String text() {


### PR DESCRIPTION
Closes https://github.com/neoforged/NeoForge/issues/1337

Figured that offheap doesn't really help diagnosis issues or help in any way. Removing it and replacing Heap with Memory will help players understand the screen much better
![image](https://github.com/user-attachments/assets/9e5faee7-9f0b-4a6b-a128-d39b8038dfa2)
