### PR TITLE
Fix window icon not being set on startup.

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -459,6 +459,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
             try (GLFWImage glfwImages = GLFWImage.malloc()) {
                 imgBuffer = STBHelper.loadImageFromClasspath("neoforged_icon.png", 20000, x, y, channels);
                 glfwImgBuffer.put(glfwImages.set(x[0], y[0], imgBuffer));
+                glfwImgBuffer.flip();
                 glfwSetWindowIcon(window, glfwImgBuffer);
                 STBImage.stbi_image_free(imgBuffer);
             }


### PR DESCRIPTION
Fixes the NeoForge icon not correctly being set since the `put` advanced the buffer thus making LWJGL think the icon array is empty.

![image](https://github.com/user-attachments/assets/bae46a3a-5528-4632-9233-518c4944ed08)

![image](https://github.com/user-attachments/assets/9bcdedee-836b-498d-9c08-d978c5a0bf1e)

p.s.: the icon will switch back to a Minecraft icon as normal when Vanilla takes over.
