### PR TITLE
Fix: Disambiguate libraries by their module name.

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/locators/JarInJarDependencyLocator.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/locators/JarInJarDependencyLocator.java
@@ -109,8 +109,13 @@ public class JarInJarDependencyLocator implements IDependencyLocator {
     }
 
     protected String identifyMod(final IModFile modFile) {
-        if (modFile.getModFileInfo() == null || modFile.getModInfos().isEmpty()) {
+        if (modFile.getModFileInfo() == null) {
             return modFile.getFileName();
+        }
+        // If this is a library, it won't have any mod IDs, so we use the module name instead.
+        if (modFile.getModInfos().isEmpty()) {
+            // Prefix to ensure this cannot collide with any true mod ID.
+            return "library:" + modFile.getModFileInfo().moduleName();
         }
 
         return modFile.getModInfos().stream().map(IModInfo::getModId).collect(Collectors.joining());

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/readers/JarModsDotTomlModFileReader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/readers/JarModsDotTomlModFileReader.java
@@ -140,12 +140,12 @@ public class JarModsDotTomlModFileReader implements IModFileReader {
             return configurable;
         }
 
-        // These Should never be called as it's only called from ModJarMetadata.version and we bypass that
         @Override
         public String moduleName() {
             return mod.getSecureJar().name();
         }
 
+        // These Should never be called as it's only called from ModJarMetadata.version and we bypass that
         @Override
         public String versionString() {
             return null;


### PR DESCRIPTION
MixinExtras is a library rather than a mod, at the request of the team, but this means that JiJ'ed versions are not correctly grouped since the current logic uses the filename.
This allows users to JiJ new stable versions of mixinextras.
There is another bug with the module name detection for beta versions, but I will fix that separately by setting an `Automatic-Module-Name`.