### PR TITLE
Fix neoforgeclientdev not updating arguments

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/targets/NeoForgeClientDevLaunchHandler.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/targets/NeoForgeClientDevLaunchHandler.java
@@ -41,7 +41,7 @@ public class NeoForgeClientDevLaunchHandler extends NeoForgeDevLaunchHandler {
             args.put("accessToken", "0");
         }
 
-        return super.preLaunch(arguments, layer);
+        return super.preLaunch(args.getArguments(), layer);
     }
 
     @Override


### PR DESCRIPTION
Fixes the `neoforgeclientdev` target not updating the launch arguments.