### PR TITLE
Update junit launch target to have the name `neoforgejunitdev`

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/targets/JUnitDevLaunchTarget.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/targets/JUnitDevLaunchTarget.java
@@ -23,6 +23,6 @@ public class JUnitDevLaunchTarget extends NeoForgeDevLaunchHandler {
 
     @Override
     public String name() {
-        return "forgejunitdev";
+        return "neoforgejunitdev";
     }
 }


### PR DESCRIPTION
Updates the name of the junit launch target to be `neoforgejunitdev`