### PR TITLE
Fix server stop/shutdown hang by stopping the FileWatcher when unloading configs.

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
@@ -127,6 +127,9 @@ public class ConfigTracker {
     public void unloadConfigs(ModConfig.Type type) {
         LOGGER.debug(CONFIG, "Unloading configs type {}", type);
         this.configSets.get(type).forEach(ConfigTracker::closeConfig);
+        if (!FMLConfig.getBoolConfigValue(FMLConfig.ConfigValue.DISABLE_CONFIG_WATCHER)) {
+            FileWatcher.defaultInstance().stop();
+        }
     }
 
     static void openConfig(ModConfig config, Path configBasePath, @Nullable Path configOverrideBasePath) {


### PR DESCRIPTION
The FileWatcher needs to be stopped somewhere otherwise the jvm will hang on exit because it is keeping a ScheduledExecutorService thread pool alive with non-daemon threads. Since ConfigTracker.unloadConfigs is called during server stop, it seems like an ok place to also stop the FileWatcher.

Note that the FileWatcher's ScheduledExecutorService thread pool will on demand create threads when work is scheduled to the pool. If no config files the watcher is watching change, then no work will be scheduled and the pool will remain at 0 threads. However, once a config file changes, the watcher will schedule work to the pool and a non-daemon thread will be created. Once this occurs, the non-daemon thread from the pool will keep jvm alive and prevent it from exiting after trying to gracefully stop the server. The jvm must be killed from this point on, unless the FileWatcher is told to stop so that it can teardown the pool.

I think this unfortunately affects all versions, so it should probably be merged everywhere.