### PR TITLE
Prevent mods from modifying the mod list

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModList.java
+++ b/loader/src/main/java/net/neoforged/fml/ModList.java
@@ -9,7 +9,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
@@ -49,7 +48,7 @@ public class ModList {
     private ModList(final List<ModFile> modFiles, final List<ModInfo> sortedList) {
         this.modFiles = modFiles.stream().map(ModFile::getModFileInfo).toList();
         this.sortedList = sortedList.stream().map(IModInfo.class::cast).toList();
-        this.fileById = Collections.unmodifiableMap(this.modFiles.stream().map(IModFileInfo::getMods).flatMap(Collection::stream).map(ModInfo.class::cast).collect(Collectors.toMap(ModInfo::getModId, ModInfo::getOwningFile)));
+        this.fileById = this.modFiles.stream().map(IModFileInfo::getMods).flatMap(Collection::stream).map(ModInfo.class::cast).collect(Collectors.toUnmodifiableMap(ModInfo::getModId, ModInfo::getOwningFile));
         CrashReportCallables.registerCrashCallable("Mod List", this::crashReport);
     }
 


### PR DESCRIPTION
This is basically guaranteed to cause unexpected/difficult to debug behavior if someone tries it (accidentally or otherwise).