### PR TITLE
Change the name of the thread used by the NeoForge version checker

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/VersionChecker.java
+++ b/loader/src/main/java/net/neoforged/fml/VersionChecker.java
@@ -91,7 +91,7 @@ public class VersionChecker {
     public record CheckResult(VersionChecker.Status status, ComparableVersion target, Map<ComparableVersion, String> changes, String url) {}
 
     public static void startVersionCheck() {
-        new Thread("Forge Version Check") {
+        new Thread("NeoForge Version Check") {
             private HttpClient client;
 
             @Override


### PR DESCRIPTION
Change the name of the thread used by the NeoForge version checker

`Forge Version Check` -> `NeoForge Version Check`

