### PR TITLE
Stop version number from overlapping running fox in loading screen

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/RenderElement.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/RenderElement.java
@@ -141,8 +141,8 @@ public class RenderElement {
             int offset = outsize / 6;
             var x0 = context.scaledWidth() - outsize * context.scale() + offset;
             var x1 = context.scaledWidth() + offset;
-            var y0 = context.scaledHeight() - outsize * context.scale() / aspect - font.descent() - font.lineSpacing();
-            var y1 = context.scaledHeight() - font.descent() - font.lineSpacing();
+            var y0 = context.scaledHeight() - outsize * context.scale() / aspect - font.descent() - font.lineSpacing() - 10;
+            var y1 = context.scaledHeight() - font.descent() - font.lineSpacing() - 10;
             int frameidx = frame % framecount;
             float framesize = 1 / (float) framecount;
             float framepos = frameidx * framesize;


### PR DESCRIPTION
Right now, the animation of the running fox in the loading screen is overlapped by the NeoForge version number below it. This is because the fox is only as high as the version number's height; it does not account for the space below the version number. This PR fixes that (presumed) oversight.

Before this PR:

![before](https://github.com/user-attachments/assets/21fde7d9-fa2a-47ae-9c94-0bdee3275e57)

With this PR:

![after](https://github.com/user-attachments/assets/cd7771fb-9292-4b29-bc38-8b625a7a57e8)


