### PR TITLE
Clean up built-in "minecraft" mod metadata

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/locators/MinecraftModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/locators/MinecraftModInfo.java
@@ -24,12 +24,13 @@ final class MinecraftModInfo {
         final var conf = Config.inMemory();
         conf.set("modLoader", "minecraft");
         conf.set("loaderVersion", "1");
-        conf.set("license", "Mojang Studios, All Rights Reserved");
+        conf.set("license", "All Rights Reserved");
         final var mods = Config.inMemory();
         mods.set("modId", "minecraft");
         mods.set("version", FMLLoader.versionInfo().mcVersion());
         mods.set("displayName", "Minecraft");
-        mods.set("description", "Minecraft");
+        mods.set("authors", "Mojang Studios");
+        mods.set("description", "");
         conf.set("mods", List.of(mods));
 
         final NightConfigWrapper configWrapper = new NightConfigWrapper(conf);


### PR DESCRIPTION
This cleans up the metadata for the built-in mod representing Minecraft (mod id `minecraft`), splitting the author credit off to its own line and blanking out the description (which is currently just "Minecraft", redundantly). If any maintainers want to write a more proper description for the game instead, feel free to edit this PR.

Before this PR:

![before](https://github.com/user-attachments/assets/06189ea2-6e2e-4915-8fb1-2f308c9c62e3)

With this PR:

![after](https://github.com/user-attachments/assets/570f200a-da52-4a0b-ab17-dbed885dc6eb)
