### PR TITLE
Increase early window creation timeout to 30 seconds

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -391,7 +391,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         var successfulWindow = new AtomicBoolean(false);
         var windowFailFuture = renderScheduler.schedule(() -> {
             if (!successfulWindow.get()) crashElegantly("Timed out trying to setup the Game Window.");
-        }, 10, TimeUnit.SECONDS);
+        }, 30, TimeUnit.SECONDS);
         int versidx = 0;
         var skipVersions = FMLConfig.<String>getListConfigValue(FMLConfig.ConfigValue.EARLY_WINDOW_SKIP_GL_VERSIONS);
         final String[] lastGLError = new String[GL_VERSIONS.length];


### PR DESCRIPTION
A regression was introduced in Intel Arc driver update 32.0.101.6559 which is causing OpenGL context initialization to take an extremely long time (~12 seconds) when starting Minecraft. This problem affects Vanilla as well, but only NeoForge has a window creation timeout, which results in the game being prematurely terminated.

As a short-term solution, this patch increases the timeout to 30 seconds, which is a long enough period for the driver to take care of what it needs to.

Note that the underlying problem here needs to be reported to Intel, as context creation shouldn't take this long. But seeing as they've rolled out this WHQL driver update, it is the unfortunate situation that we have to deal with it.