### PR TITLE
Add config for enabling synchronous GL debug output

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/FMLConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLConfig.java
@@ -46,7 +46,9 @@ public class FMLConfig {
         EARLY_WINDOW_FBSCALE("earlyWindowFBScale", 1, "Early window framebuffer scale"),
         EARLY_WINDOW_MAXIMIZED("earlyWindowMaximized", Boolean.FALSE, "Early window starts maximized"),
         EARLY_WINDOW_SKIP_GL_VERSIONS("earlyWindowSkipGLVersions", List.of(), "Skip specific GL versions, may help with buggy graphics card drivers"),
-        EARLY_WINDOW_SQUIR("earlyWindowSquir", Boolean.FALSE, "Squir?");
+        EARLY_WINDOW_SQUIR("earlyWindowSquir", Boolean.FALSE, "Squir?"),
+        SYNC_GL_DEBUG("syncGlDebug", Boolean.FALSE, "If true, OpenGL will be configured to output debug messages synchronously to aid in debugging"),
+        ;
 
         private final String entry;
         private final Object defaultValue;


### PR DESCRIPTION
This PR adds a config for enabling synchronous GL debug output. The functionality of actually enabling this will be done in a NeoForge PR.