### PR TITLE
Catch any exception during EBS injection

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/javafmlmod/AutomaticEventSubscriber.java
+++ b/loader/src/main/java/net/neoforged/fml/javafmlmod/AutomaticEventSubscriber.java
@@ -59,7 +59,7 @@ public class AutomaticEventSubscriber {
 
                         bus.register(Class.forName(ad.clazz().getClassName(), true, layer.getClassLoader()));
                     }
-                } catch (ClassNotFoundException e) {
+                } catch (Exception e) {
                     LOGGER.fatal(LOADING, "Failed to load mod class {} for @EventBusSubscriber annotation", ad.clazz(), e);
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
For some reason EBS injection only caught and rethrew with more details CNFEs, this PR widens it to all exceptions (like exceptions caused by the dist cleaner)