### PR TITLE
Add OpenGL state tracking

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/EarlyFramebuffer.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/EarlyFramebuffer.java
@@ -19,22 +19,22 @@ public class EarlyFramebuffer {
         this.context = context;
         this.framebuffer = glGenFramebuffers();
         this.texture = glGenTextures();
-        glBindFramebuffer(GL_FRAMEBUFFER, this.framebuffer);
-        glActiveTexture(GL_TEXTURE0);
-        glBindTexture(GL_TEXTURE_2D, this.texture);
+        GlState.bindFramebuffer(this.framebuffer);
+        GlState.activeTexture(GL_TEXTURE0);
+        GlState.bindTexture2D(this.texture);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, context.width() * context.scale(), context.height() * context.scale(), 0, GL_RGBA, GL_UNSIGNED_BYTE, (IntBuffer) null);
         glTexParameterIi(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameterIi(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, this.texture, 0);
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        GlState.bindFramebuffer(0);
     }
 
     void activate() {
-        glBindFramebuffer(GL_FRAMEBUFFER, this.framebuffer);
+        GlState.bindFramebuffer(this.framebuffer);
     }
 
     void deactivate() {
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        GlState.bindFramebuffer(0);
     }
 
     void draw(int windowFBWidth, int windowFBHeight) {
@@ -45,14 +45,14 @@ public class EarlyFramebuffer {
         var wtop = (int) (windowFBHeight * 0.5f - scale * this.context.height());
         var wright = (int) (windowFBWidth * 0.5f + scale * this.context.width());
         var wbottom = (int) (windowFBHeight * 0.5f + scale * this.context.height());
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, this.framebuffer);
+        GlState.bindDrawFramebuffer(0);
+        GlState.bindReadFramebuffer(this.framebuffer);
         final var colour = this.context.colourScheme().background();
-        glClearColor(colour.redf(), colour.greenf(), colour.bluef(), 1f);
+        GlState.clearColor(colour.redf(), colour.greenf(), colour.bluef(), 1f);
         glClear(GL_COLOR_BUFFER_BIT);
         // src Y are flipped, since our FB is flipped
         glBlitFramebuffer(0, this.context.height() * this.context.scale(), this.context.width() * this.context.scale(), 0, RenderElement.clamp(wleft, 0, windowFBWidth), RenderElement.clamp(wtop, 0, windowFBHeight), RenderElement.clamp(wright, 0, windowFBWidth), RenderElement.clamp(wbottom, 0, windowFBHeight), GL_COLOR_BUFFER_BIT, GL_NEAREST);
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        GlState.bindFramebuffer(0);
     }
 
     int getTexture() {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/ElementShader.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/ElementShader.java
@@ -84,7 +84,7 @@ public class ElementShader {
     }
 
     public void activate() {
-        glUseProgram(program);
+        GlState.useProgram(program);
     }
 
     public void updateTextureUniform(int textureNumber) {
@@ -100,7 +100,7 @@ public class ElementShader {
     }
 
     public void clear() {
-        glUseProgram(0);
+        GlState.useProgram(0);
     }
 
     public void close() {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/GlState.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/GlState.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.fml.earlydisplay;
+
+import static org.lwjgl.opengl.GL32C.GL_ACTIVE_TEXTURE;
+import static org.lwjgl.opengl.GL32C.GL_ARRAY_BUFFER;
+import static org.lwjgl.opengl.GL32C.GL_ARRAY_BUFFER_BINDING;
+import static org.lwjgl.opengl.GL32C.GL_BLEND;
+import static org.lwjgl.opengl.GL32C.GL_BLEND_DST_ALPHA;
+import static org.lwjgl.opengl.GL32C.GL_BLEND_DST_RGB;
+import static org.lwjgl.opengl.GL32C.GL_BLEND_SRC_ALPHA;
+import static org.lwjgl.opengl.GL32C.GL_BLEND_SRC_RGB;
+import static org.lwjgl.opengl.GL32C.GL_COLOR_CLEAR_VALUE;
+import static org.lwjgl.opengl.GL32C.GL_CURRENT_PROGRAM;
+import static org.lwjgl.opengl.GL32C.GL_DRAW_FRAMEBUFFER;
+import static org.lwjgl.opengl.GL32C.GL_DRAW_FRAMEBUFFER_BINDING;
+import static org.lwjgl.opengl.GL32C.GL_ELEMENT_ARRAY_BUFFER;
+import static org.lwjgl.opengl.GL32C.GL_ELEMENT_ARRAY_BUFFER_BINDING;
+import static org.lwjgl.opengl.GL32C.GL_FRAMEBUFFER;
+import static org.lwjgl.opengl.GL32C.GL_READ_FRAMEBUFFER;
+import static org.lwjgl.opengl.GL32C.GL_READ_FRAMEBUFFER_BINDING;
+import static org.lwjgl.opengl.GL32C.GL_TEXTURE0;
+import static org.lwjgl.opengl.GL32C.GL_TEXTURE_2D;
+import static org.lwjgl.opengl.GL32C.GL_TEXTURE_BINDING_2D;
+import static org.lwjgl.opengl.GL32C.GL_TRUE;
+import static org.lwjgl.opengl.GL32C.GL_VERTEX_ARRAY_BINDING;
+import static org.lwjgl.opengl.GL32C.GL_VERTEX_ATTRIB_ARRAY_ENABLED;
+import static org.lwjgl.opengl.GL32C.GL_VIEWPORT;
+import static org.lwjgl.opengl.GL32C.glActiveTexture;
+import static org.lwjgl.opengl.GL32C.glBindBuffer;
+import static org.lwjgl.opengl.GL32C.glBindFramebuffer;
+import static org.lwjgl.opengl.GL32C.glBindTexture;
+import static org.lwjgl.opengl.GL32C.glBindVertexArray;
+import static org.lwjgl.opengl.GL32C.glBlendFuncSeparate;
+import static org.lwjgl.opengl.GL32C.glClearColor;
+import static org.lwjgl.opengl.GL32C.glDisable;
+import static org.lwjgl.opengl.GL32C.glDisableVertexAttribArray;
+import static org.lwjgl.opengl.GL32C.glEnable;
+import static org.lwjgl.opengl.GL32C.glEnableVertexAttribArray;
+import static org.lwjgl.opengl.GL32C.glGetFloatv;
+import static org.lwjgl.opengl.GL32C.glGetInteger;
+import static org.lwjgl.opengl.GL32C.glGetIntegerv;
+import static org.lwjgl.opengl.GL32C.glGetVertexAttribi;
+import static org.lwjgl.opengl.GL32C.glIsEnabled;
+import static org.lwjgl.opengl.GL32C.glUseProgram;
+import static org.lwjgl.opengl.GL32C.glViewport;
+
+/**
+ * A static state manager for a subset of OpenGL states to minimize redundant state changes.
+ * <p>
+ * This class tracks the current state of various OpenGL state elements and only applies changes
+ * when necessary, reducing overhead from redundant state changes.
+ */
+final class GlState {
+    // Viewport state
+    private static int viewportX;
+    private static int viewportY;
+    private static int viewportWidth;
+    private static int viewportHeight;
+
+    // Clear color state
+    private static float clearColorRed;
+    private static float clearColorGreen;
+    private static float clearColorBlue;
+    private static float clearColorAlpha;
+
+    // Blend state
+    private static boolean blendEnabled;
+    private static int blendSrcRGB;
+    private static int blendDstRGB;
+    private static int blendSrcAlpha;
+    private static int blendDstAlpha;
+
+    // Program state
+    private static int currentProgram;
+
+    // Texture state
+    private static int boundTexture2D;
+    private static int activeTextureUnit;
+
+    // Vertex array state
+    private static int boundVertexArray;
+    private static final boolean[] enabledVertexAttribArrays = new boolean[16];
+
+    // Framebuffer states
+    private static int boundDrawFramebuffer;
+    private static int boundReadFramebuffer;
+
+    // Buffer states
+    private static int boundElementArrayBuffer;
+    private static int boundArrayBuffer;
+
+    /**
+     * Private constructor to prevent instantiation of this utility class.
+     */
+    private GlState() {
+        // This class should not be instantiated
+    }
+
+    /**
+     * Reads the current OpenGL state into this state manager.
+     */
+    public static void readFromOpenGL() {
+        // Read viewport state
+        int[] viewport = new int[4];
+        glGetIntegerv(GL_VIEWPORT, viewport);
+        viewportX = viewport[0];
+        viewportY = viewport[1];
+        viewportWidth = viewport[2];
+        viewportHeight = viewport[3];
+
+        // Read clear color state
+        float[] clearColor = new float[4];
+        glGetFloatv(GL_COLOR_CLEAR_VALUE, clearColor);
+        clearColorRed = clearColor[0];
+        clearColorGreen = clearColor[1];
+        clearColorBlue = clearColor[2];
+        clearColorAlpha = clearColor[3];
+
+        // Read blend state
+        blendEnabled = glIsEnabled(GL_BLEND);
+        blendSrcRGB = glGetInteger(GL_BLEND_SRC_RGB);
+        blendDstRGB = glGetInteger(GL_BLEND_DST_RGB);
+        blendSrcAlpha = glGetInteger(GL_BLEND_SRC_ALPHA);
+        blendDstAlpha = glGetInteger(GL_BLEND_DST_ALPHA);
+
+        // Read program state
+        currentProgram = glGetInteger(GL_CURRENT_PROGRAM);
+
+        // Read texture state
+        activeTextureUnit = GL_TEXTURE0 + glGetInteger(GL_ACTIVE_TEXTURE) - GL_TEXTURE0;
+        boundTexture2D = glGetInteger(GL_TEXTURE_BINDING_2D);
+
+        // Read vertex array state
+        boundVertexArray = glGetInteger(GL_VERTEX_ARRAY_BINDING);
+        for (int i = 0; i < enabledVertexAttribArrays.length; i++) {
+            enabledVertexAttribArrays[i] = glGetVertexAttribi(i, GL_VERTEX_ATTRIB_ARRAY_ENABLED) == GL_TRUE;
+        }
+
+        // Read framebuffer states
+        boundDrawFramebuffer = glGetInteger(GL_DRAW_FRAMEBUFFER_BINDING);
+        boundReadFramebuffer = glGetInteger(GL_READ_FRAMEBUFFER_BINDING);
+
+        // Read buffer states
+        boundElementArrayBuffer = glGetInteger(GL_ELEMENT_ARRAY_BUFFER_BINDING);
+        boundArrayBuffer = glGetInteger(GL_ARRAY_BUFFER_BINDING);
+    }
+
+    /**
+     * Sets the viewport state.
+     *
+     * @param x      The lower left corner x-coordinate
+     * @param y      The lower left corner y-coordinate
+     * @param width  The viewport width
+     * @param height The viewport height
+     */
+    public static void viewport(int x, int y, int width, int height) {
+        if (x != viewportX || y != viewportY || width != viewportWidth || height != viewportHeight) {
+            glViewport(x, y, width, height);
+            viewportX = x;
+            viewportY = y;
+            viewportWidth = width;
+            viewportHeight = height;
+        }
+    }
+
+    /**
+     * Sets the clear color state.
+     *
+     * @param red   The red component [0.0, 1.0]
+     * @param green The green component [0.0, 1.0]
+     * @param blue  The blue component [0.0, 1.0]
+     * @param alpha The alpha component [0.0, 1.0]
+     */
+    public static void clearColor(float red, float green, float blue, float alpha) {
+        if (red != clearColorRed || green != clearColorGreen ||
+                blue != clearColorBlue || alpha != clearColorAlpha) {
+            glClearColor(red, green, blue, alpha);
+            clearColorRed = red;
+            clearColorGreen = green;
+            clearColorBlue = blue;
+            clearColorAlpha = alpha;
+        }
+    }
+
+    /**
+     * Enables or disables blending.
+     *
+     * @param enabled Whether blending should be enabled
+     */
+    public static void enableBlend(boolean enabled) {
+        if (enabled != blendEnabled) {
+            if (enabled) {
+                glEnable(GL_BLEND);
+            } else {
+                glDisable(GL_BLEND);
+            }
+            blendEnabled = enabled;
+        }
+    }
+
+    /**
+     * Sets the blend function parameters.
+     *
+     * @param srcRGB   The source RGB factor
+     * @param dstRGB   The destination RGB factor
+     * @param srcAlpha The source alpha factor
+     * @param dstAlpha The destination alpha factor
+     */
+    public static void blendFuncSeparate(int srcRGB, int dstRGB, int srcAlpha, int dstAlpha) {
+        if (srcRGB != blendSrcRGB || dstRGB != blendDstRGB ||
+                srcAlpha != blendSrcAlpha || dstAlpha != blendDstAlpha) {
+            glBlendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+            blendSrcRGB = srcRGB;
+            blendDstRGB = dstRGB;
+            blendSrcAlpha = srcAlpha;
+            blendDstAlpha = dstAlpha;
+        }
+    }
+
+    /**
+     * Sets the current shader program.
+     *
+     * @param program The program ID to use
+     */
+    public static void useProgram(int program) {
+        if (program != currentProgram) {
+            glUseProgram(program);
+            currentProgram = program;
+        }
+    }
+
+    /**
+     * Sets the active texture unit.
+     *
+     * @param textureUnit The texture unit (e.g., GL_TEXTURE0)
+     */
+    public static void activeTexture(int textureUnit) {
+        if (textureUnit != activeTextureUnit) {
+            glActiveTexture(textureUnit);
+            activeTextureUnit = textureUnit;
+        }
+    }
+
+    /**
+     * Binds a 2D texture.
+     *
+     * @param textureId The texture ID to bind
+     */
+    public static void bindTexture2D(int textureId) {
+        if (textureId != boundTexture2D) {
+            glBindTexture(GL_TEXTURE_2D, textureId);
+            boundTexture2D = textureId;
+        }
+    }
+
+    /**
+     * Binds a vertex array object.
+     *
+     * @param vaoId The vertex array object ID to bind
+     */
+    public static void bindVertexArray(int vaoId) {
+        if (vaoId != boundVertexArray) {
+            glBindVertexArray(vaoId);
+            boundVertexArray = vaoId;
+        }
+    }
+
+    /**
+     * Binds a framebuffer to both draw and read targets.
+     *
+     * @param framebufferId The framebuffer ID to bind to both GL_FRAMEBUFFER targets
+     */
+    public static void bindFramebuffer(int framebufferId) {
+        if (framebufferId != boundDrawFramebuffer || framebufferId != boundReadFramebuffer) {
+            glBindFramebuffer(GL_FRAMEBUFFER, framebufferId);
+            boundDrawFramebuffer = framebufferId;
+            boundReadFramebuffer = framebufferId;
+        }
+    }
+
+    /**
+     * Binds a framebuffer to the draw target.
+     *
+     * @param framebufferId The framebuffer ID to bind to GL_DRAW_FRAMEBUFFER
+     */
+    public static void bindDrawFramebuffer(int framebufferId) {
+        if (framebufferId != boundDrawFramebuffer) {
+            glBindFramebuffer(GL_DRAW_FRAMEBUFFER, framebufferId);
+            boundDrawFramebuffer = framebufferId;
+        }
+    }
+
+    /**
+     * Binds a framebuffer to the read target.
+     *
+     * @param framebufferId The framebuffer ID to bind to GL_READ_FRAMEBUFFER
+     */
+    public static void bindReadFramebuffer(int framebufferId) {
+        if (framebufferId != boundReadFramebuffer) {
+            glBindFramebuffer(GL_READ_FRAMEBUFFER, framebufferId);
+            boundReadFramebuffer = framebufferId;
+        }
+    }
+
+    /**
+     * Binds a buffer to the element array buffer target.
+     *
+     * @param bufferId The buffer ID to bind
+     */
+    public static void bindElementArrayBuffer(int bufferId) {
+        if (bufferId != boundElementArrayBuffer) {
+            glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, bufferId);
+            boundElementArrayBuffer = bufferId;
+        }
+    }
+
+    /**
+     * Binds a buffer to the array buffer target.
+     *
+     * @param bufferId The buffer ID to bind
+     */
+    public static void bindArrayBuffer(int bufferId) {
+        if (bufferId != boundArrayBuffer) {
+            glBindBuffer(GL_ARRAY_BUFFER, bufferId);
+            boundArrayBuffer = bufferId;
+        }
+    }
+
+    /**
+     * Enables or disables a vertex attribute array.
+     *
+     * @param index   The attribute index
+     * @param enabled Whether the attribute should be enabled
+     */
+    public static void enableVertexAttribArray(int index, boolean enabled) {
+        if (index >= 0 && index < enabledVertexAttribArrays.length && enabled != enabledVertexAttribArrays[index]) {
+            if (enabled) {
+                glEnableVertexAttribArray(index);
+            } else {
+                glDisableVertexAttribArray(index);
+            }
+            enabledVertexAttribArrays[index] = enabled;
+        }
+    }
+
+    /**
+     * A record class representing a snapshot of the OpenGL state.
+     */
+    public record StateSnapshot(
+            int viewportX, int viewportY, int viewportWidth, int viewportHeight,
+            float clearColorRed, float clearColorGreen, float clearColorBlue, float clearColorAlpha,
+            boolean blendEnabled,
+            int blendSrcRGB, int blendDstRGB, int blendSrcAlpha, int blendDstAlpha,
+            int currentProgram,
+            int boundTexture2D, int activeTextureUnit,
+            int boundVertexArray, boolean[] enabledVertexAttribArrays,
+            int boundDrawFramebuffer, int boundReadFramebuffer,
+            int boundElementArrayBuffer, int boundArrayBuffer) {
+        /**
+         * Creates a copy of the enabledVertexAttribArrays to avoid sharing arrays.
+         */
+        public StateSnapshot {
+            enabledVertexAttribArrays = enabledVertexAttribArrays.clone();
+        }
+    }
+
+    /**
+     * Creates a snapshot of the current OpenGL state.
+     *
+     * @return A StateSnapshot object containing the current state
+     */
+    public static StateSnapshot createSnapshot() {
+        return new StateSnapshot(
+                viewportX, viewportY, viewportWidth, viewportHeight,
+                clearColorRed, clearColorGreen, clearColorBlue, clearColorAlpha,
+                blendEnabled,
+                blendSrcRGB, blendDstRGB, blendSrcAlpha, blendDstAlpha,
+                currentProgram,
+                boundTexture2D, activeTextureUnit,
+                boundVertexArray, enabledVertexAttribArrays.clone(),
+                boundDrawFramebuffer, boundReadFramebuffer,
+                boundElementArrayBuffer, boundArrayBuffer);
+    }
+
+    /**
+     * Applies the state from a snapshot to both this state manager and OpenGL.
+     *
+     * @param snapshot The snapshot to apply
+     */
+    public static void applySnapshot(StateSnapshot snapshot) {
+        viewport(snapshot.viewportX, snapshot.viewportY, snapshot.viewportWidth, snapshot.viewportHeight);
+        clearColor(snapshot.clearColorRed, snapshot.clearColorGreen, snapshot.clearColorBlue, snapshot.clearColorAlpha);
+        enableBlend(snapshot.blendEnabled);
+        blendFuncSeparate(snapshot.blendSrcRGB, snapshot.blendDstRGB, snapshot.blendSrcAlpha, snapshot.blendDstAlpha);
+        useProgram(snapshot.currentProgram);
+        activeTexture(snapshot.activeTextureUnit);
+        bindTexture2D(snapshot.boundTexture2D);
+        bindVertexArray(snapshot.boundVertexArray);
+        // Handle framebuffers - check if both are the same
+        if (snapshot.boundDrawFramebuffer == snapshot.boundReadFramebuffer) {
+            bindFramebuffer(snapshot.boundDrawFramebuffer);
+        } else {
+            bindDrawFramebuffer(snapshot.boundDrawFramebuffer);
+            bindReadFramebuffer(snapshot.boundReadFramebuffer);
+        }
+        bindElementArrayBuffer(snapshot.boundElementArrayBuffer);
+        bindArrayBuffer(snapshot.boundArrayBuffer);
+
+        // Apply vertex attribute array states
+        for (int i = 0; i < snapshot.enabledVertexAttribArrays.length; i++) {
+            enableVertexAttribArray(i, snapshot.enabledVertexAttribArrays[i]);
+        }
+    }
+}

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/RenderElement.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/RenderElement.java
@@ -100,12 +100,12 @@ public class RenderElement {
             ctx.elementShader().updateTextureUniform(0);
             ctx.elementShader().updateRenderTypeUniform(ElementShader.RenderType.TEXTURE);
             var fade = Math.min((frame - frameStart) * 10, 255);
-            glBindTexture(GL_TEXTURE_2D, textureId);
+            GlState.bindTexture2D(textureId);
             bb.begin(SimpleBufferBuilder.Format.POS_TEX_COLOR, SimpleBufferBuilder.Mode.QUADS);
             QuadHelper.loadQuad(bb, x0, x0 + size, y0, y0 + size / 2f, 0f, 1f, 0f, 0.5f, ctx.colourScheme.foreground().packedint(fade));
             QuadHelper.loadQuad(bb, x0 + size, x0 + 2 * size, y0, y0 + size / 2f, 0f, 1f, 0.5f, 1f, ctx.colourScheme.foreground().packedint(fade));
             bb.draw();
-            glBindTexture(GL_TEXTURE_2D, 0);
+            GlState.bindTexture2D(0);
         });
     }
 

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/STBHelper.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/STBHelper.java
@@ -45,14 +45,14 @@ public class STBHelper {
         int[] lc = new int[1];
         var img = loadImageFromClasspath(file, size, lw, lh, lc);
         var texid = glGenTextures();
-        glActiveTexture(textureNumber);
-        glBindTexture(GL_TEXTURE_2D, texid);
+        GlState.activeTexture(textureNumber);
+        GlState.bindTexture2D(texid);
 //        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 //        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, lw[0], lh[0], 0, GL_RGBA, GL_UNSIGNED_BYTE, img);
-        glActiveTexture(GL_TEXTURE0);
+        GlState.activeTexture(GL_TEXTURE0);
         MemoryUtil.memFree(img);
         return new int[] { lw[0], lh[0] };
     }

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleBufferBuilder.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleBufferBuilder.java
@@ -95,7 +95,7 @@ public class SimpleBufferBuilder implements Closeable {
         final var newIndexCount = newElementBufferVertexLength + newElementBufferVertexLength / 2;
 
         // allocate new buffer
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, newElementBuffer);
+        GlState.bindElementArrayBuffer(newElementBuffer);
         glBufferData(GL_ELEMENT_ARRAY_BUFFER, newIndexCount * 4L, GL_STATIC_DRAW);
 
         // mapping avoids creating additional CPU copies of the data
@@ -127,7 +127,7 @@ public class SimpleBufferBuilder implements Closeable {
             glCopyBufferSubData(GL_COPY_READ_BUFFER, GL_ELEMENT_ARRAY_BUFFER, 0, 0, mappingOffset);
             glBindBuffer(GL_COPY_READ_BUFFER, 0);
         }
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+        GlState.bindElementArrayBuffer(0);
 
         glDeleteBuffers(elementBuffer);
         elementBuffer = newElementBuffer;
@@ -328,7 +328,7 @@ public class SimpleBufferBuilder implements Closeable {
             // Upload the raw vertex data in dynamic mode.
             final int vbo = VERTEX_BUFFERS[format.ordinal()];
             final int vboSize = VERTEX_BUFFER_LENGTHS[format.ordinal()];
-            glBindBuffer(GL_ARRAY_BUFFER, vbo);
+            GlState.bindArrayBuffer(vbo);
             if (vboSize < index) {
                 // expand buffer, it's not big enough
                 var newVBOSize = Math.max(1024, vboSize);
@@ -348,7 +348,7 @@ public class SimpleBufferBuilder implements Closeable {
 
             if (mode == Mode.QUADS) {
                 ensureElementBufferLength(vertices);
-                glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, elementBuffer);
+                GlState.bindElementArrayBuffer(elementBuffer);
             }
 
             return indices;
@@ -388,13 +388,13 @@ public class SimpleBufferBuilder implements Closeable {
 
             // Ask our Format to set up its data layout for the vertex array.
             // but only once, the VAO saves this state
-            glBindVertexArray(vao);
-            glBindBuffer(GL_ARRAY_BUFFER, vbo);
+            GlState.bindVertexArray(vao);
+            GlState.bindArrayBuffer(vbo);
             format.bind();
             format.enable();
         }
         // Bind the vertex array and buffers!
-        glBindVertexArray(vao);
+        GlState.bindVertexArray(vao);
 
         // Upload the data.
         int indices = finishAndUpload();
@@ -406,7 +406,7 @@ public class SimpleBufferBuilder implements Closeable {
         }
 
         // Unbind the vertex array.
-        glBindVertexArray(0);
+        GlState.bindVertexArray(0);
     }
 
     /**
@@ -500,7 +500,7 @@ public class SimpleBufferBuilder implements Closeable {
          */
         public void enable() {
             for (int i = 0; i < types.length; i++) {
-                glEnableVertexAttribArray(i);
+                GlState.enableVertexAttribArray(i, true);
             }
         }
 
@@ -509,7 +509,7 @@ public class SimpleBufferBuilder implements Closeable {
          */
         public void disable() {
             for (int i = 0; i < types.length; i++) {
-                glDisableVertexAttribArray(i);
+                GlState.enableVertexAttribArray(i, false);
             }
         }
     }

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleFont.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleFont.java
@@ -60,7 +60,6 @@ public class SimpleFont {
         GlState.activeTexture(GL_TEXTURE0 + textureNumber);
         this.textureNumber = textureNumber;
         GlState.bindTexture2D(fontTextureId);
-        GlDebug.labelTexture(fontTextureId, "EarlyDisplay font " + fontName);
         try (var packedchars = STBTTPackedchar.malloc(GLYPH_COUNT)) {
             int texwidth = 256;
             int texheight = 128;

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleFont.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleFont.java
@@ -57,9 +57,10 @@ public class SimpleFont {
         this.lineSpacing = (int) (ascent[0] - descent[0] + lineGap[0]);
         this.descent = (int) Math.floor(descent[0]);
         int fontTextureId = glGenTextures();
-        glActiveTexture(GL_TEXTURE0 + textureNumber);
+        GlState.activeTexture(GL_TEXTURE0 + textureNumber);
         this.textureNumber = textureNumber;
-        glBindTexture(GL_TEXTURE_2D, fontTextureId);
+        GlState.bindTexture2D(fontTextureId);
+        GlDebug.labelTexture(fontTextureId, "EarlyDisplay font " + fontName);
         try (var packedchars = STBTTPackedchar.malloc(GLYPH_COUNT)) {
             int texwidth = 256;
             int texheight = 128;
@@ -83,7 +84,7 @@ public class SimpleFont {
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
                 }
             }
-            glActiveTexture(GL_TEXTURE0);
+            GlState.activeTexture(GL_TEXTURE0);
             try (var q = STBTTAlignedQuad.malloc()) {
                 float[] x = new float[1];
                 float[] y = new float[1];


### PR DESCRIPTION
EarlyDisplay has to update its loading screen framebuffer interleaved with OpenGL rendering done by Vanilla (this happens during the cross-fade between the two).
Vanilla in 1.21.5 starts aggressively caching OpenGL state in various places, making it difficult if the external rendering by EarlyDisplay leaves the context in a state different from when it started. To fix this, I introduced a state tracker that is able to initialize itself from the current OpenGL pipeline state to restore it when EarlyDisplay is done.