### PR TITLE
Reworked EarlyDisplay Texturing

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -224,7 +224,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         this.context = new RenderElement.DisplayContext(854, 480, fbScale, elementShader, colourScheme, performanceInfo);
         framebuffer = new EarlyFramebuffer(this.context);
         try {
-            this.font = new SimpleFont("Monocraft.ttf", fbScale, 200000, 1 + RenderElement.INDEX_TEXTURE_OFFSET);
+            this.font = new SimpleFont("Monocraft.ttf", fbScale, 200000);
         } catch (Throwable t) {
             LOGGER.error("Crash during font initialization", t);
             crashElegantly("An error occurred initializing a font for rendering. " + t.getMessage());

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/STBHelper.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/STBHelper.java
@@ -39,13 +39,13 @@ public class STBHelper {
         return MemoryUtil.memSlice(buf); // we trim the final buffer to the size of the content
     }
 
-    public static int[] loadTextureFromClasspath(String file, int size, int textureNumber) {
+    public static ImageTexture loadTextureFromClasspath(String file, int size) {
         int[] lw = new int[1];
         int[] lh = new int[1];
         int[] lc = new int[1];
         var img = loadImageFromClasspath(file, size, lw, lh, lc);
         var texid = glGenTextures();
-        GlState.activeTexture(textureNumber);
+        GlState.activeTexture(GL_TEXTURE0);
         GlState.bindTexture2D(texid);
         GlDebug.labelTexture(texid, "EarlyDisplay " + file);
 //        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -55,8 +55,12 @@ public class STBHelper {
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, lw[0], lh[0], 0, GL_RGBA, GL_UNSIGNED_BYTE, img);
         GlState.activeTexture(GL_TEXTURE0);
         MemoryUtil.memFree(img);
-        return new int[] { lw[0], lh[0] };
+        return new ImageTexture(
+                texid,
+                new int[] { lw[0], lh[0] });
     }
+
+    public record ImageTexture(int textureId, int[] size) {}
 
     public static ByteBuffer loadImageFromClasspath(String file, int size, int[] width, int[] height, int[] channels) {
         ByteBuffer buf = STBHelper.readFromClasspath(file, size);

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleFont.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleFont.java
@@ -19,7 +19,7 @@ import org.lwjgl.stb.STBTTPackRange;
 import org.lwjgl.stb.STBTTPackedchar;
 
 public class SimpleFont {
-    private final int textureNumber;
+    private final int textureId;
     private final int lineSpacing;
     private final int descent;
     private final int GLYPH_COUNT = 127 - 32;
@@ -42,7 +42,7 @@ public class SimpleFont {
     /**
      * Build the font and store it in the textureNumber location
      */
-    public SimpleFont(String fontName, int scale, int bufferSize, int textureNumber) {
+    public SimpleFont(String fontName, int scale, int bufferSize) {
         ByteBuffer buf = STBHelper.readFromClasspath(fontName, bufferSize);
         var info = STBTTFontinfo.create();
         if (!stbtt_InitFont(info, buf)) {
@@ -56,10 +56,10 @@ public class SimpleFont {
         stbtt_GetScaledFontVMetrics(buf, 0, fontSize, ascent, descent, lineGap);
         this.lineSpacing = (int) (ascent[0] - descent[0] + lineGap[0]);
         this.descent = (int) Math.floor(descent[0]);
-        int fontTextureId = glGenTextures();
-        GlState.activeTexture(GL_TEXTURE0 + textureNumber);
-        this.textureNumber = textureNumber;
-        GlState.bindTexture2D(fontTextureId);
+        this.textureId = glGenTextures();
+        GlState.activeTexture(GL_TEXTURE0);
+        GlState.bindTexture2D(this.textureId);
+        GlDebug.labelTexture(this.textureId, "font texture " + fontName);
         try (var packedchars = STBTTPackedchar.malloc(GLYPH_COUNT)) {
             int texwidth = 256;
             int texheight = 128;
@@ -83,7 +83,6 @@ public class SimpleFont {
                     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
                 }
             }
-            GlState.activeTexture(GL_TEXTURE0);
             try (var q = STBTTAlignedQuad.malloc()) {
                 float[] x = new float[1];
                 float[] y = new float[1];
@@ -103,8 +102,8 @@ public class SimpleFont {
         return lineSpacing;
     }
 
-    int textureNumber() {
-        return textureNumber;
+    int textureId() {
+        return textureId;
     }
 
     int descent() {


### PR DESCRIPTION
EarlyDisplay currently binds all its textures to the GL state at the same time. It essentially uses multi-texturing texturing units as "storage" for its texture handles. 
This PR changes that so that only texturing unit 0 is used, and EarlyDisplay keeps track of the GL texture ids normally.
What it does NOT fix yet is the fact that EarlyDisplay never actually deletes the textures it creates.