### PR TITLE
Add GL state snapshotting to pre-handover early window rendering

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -173,6 +173,10 @@ public class DisplayWindow implements ImmediateWindowProvider {
             }
             nextFrameTime = nt + MINFRAMETIME;
             glfwMakeContextCurrent(window);
+
+            GlState.readFromOpenGL();
+            var backup = GlState.createSnapshot();
+
             framebuffer.activate();
             GlState.viewport(0, 0, this.context.scaledWidth(), this.context.scaledHeight());
             this.context.elementShader().activate();
@@ -185,6 +189,8 @@ public class DisplayWindow implements ImmediateWindowProvider {
             framebuffer.draw(this.fbWidth, this.fbHeight);
             // Swap buffers; we're done
             glfwSwapBuffers(window);
+
+            GlState.applySnapshot(backup);
         } catch (Throwable t) {
             LOGGER.error("BARF", t);
         } finally {


### PR DESCRIPTION
A previous PR added proper GL state snapshotting to the post-handover early window render path. This PR adds the same snaphshotting to the pre-handover render path to avoid clashing with GL state modifications done by the vanilla game between the `RenderSystem.initRenderer()` call and the window handover. This fixes the GL errors in that time frame as well as Fabulous mode and entity glowing outlines being broken on 1.21.5-pre3+ when the early window is enabled.