### PR TITLE
Bump the testing Minecraft version to 1.21.5 and update MDG

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 gradleutils_version=3.0.0
 
-test_neoforge_version=21.4.101-beta
-test_minecraft_version=1.21.4
+test_neoforge_version=21.5.1-beta
+test_minecraft_version=1.21.5
 
 mergetool_version=2.0.0
 accesstransformers_version=11.0.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,13 +8,13 @@ pluginManagement {
     }
 
     plugins {
-        id 'net.neoforged.moddev' version '2.0.78'
-        id 'net.neoforged.moddev.repositories' version '2.0.78'
+        id 'net.neoforged.moddev' version '2.0.80'
+        id 'net.neoforged.moddev.repositories' version '2.0.80'
     }
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
     id 'net.neoforged.moddev.repositories'
 }
 


### PR DESCRIPTION
Required to make the tests work again with the updated early loading screen API.