### PR TITLE
Fix incorrect OpenGL API usage in early loading screen

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/EarlyFramebuffer.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/EarlyFramebuffer.java
@@ -26,8 +26,8 @@ public class EarlyFramebuffer {
         GlState.bindTexture2D(this.texture);
         GlDebug.labelTexture(this.texture, "EarlyDisplay backbuffer");
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, context.width() * context.scale(), context.height() * context.scale(), 0, GL_RGBA, GL_UNSIGNED_BYTE, (IntBuffer) null);
-        glTexParameterIi(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        glTexParameterIi(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, this.texture, 0);
         GlState.bindFramebuffer(0);
     }

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/GlState.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/GlState.java
@@ -26,9 +26,7 @@ import static org.lwjgl.opengl.GL32C.GL_READ_FRAMEBUFFER_BINDING;
 import static org.lwjgl.opengl.GL32C.GL_TEXTURE0;
 import static org.lwjgl.opengl.GL32C.GL_TEXTURE_2D;
 import static org.lwjgl.opengl.GL32C.GL_TEXTURE_BINDING_2D;
-import static org.lwjgl.opengl.GL32C.GL_TRUE;
 import static org.lwjgl.opengl.GL32C.GL_VERTEX_ARRAY_BINDING;
-import static org.lwjgl.opengl.GL32C.GL_VERTEX_ATTRIB_ARRAY_ENABLED;
 import static org.lwjgl.opengl.GL32C.GL_VIEWPORT;
 import static org.lwjgl.opengl.GL32C.glActiveTexture;
 import static org.lwjgl.opengl.GL32C.glBindBuffer;
@@ -38,13 +36,10 @@ import static org.lwjgl.opengl.GL32C.glBindVertexArray;
 import static org.lwjgl.opengl.GL32C.glBlendFuncSeparate;
 import static org.lwjgl.opengl.GL32C.glClearColor;
 import static org.lwjgl.opengl.GL32C.glDisable;
-import static org.lwjgl.opengl.GL32C.glDisableVertexAttribArray;
 import static org.lwjgl.opengl.GL32C.glEnable;
-import static org.lwjgl.opengl.GL32C.glEnableVertexAttribArray;
 import static org.lwjgl.opengl.GL32C.glGetFloatv;
 import static org.lwjgl.opengl.GL32C.glGetInteger;
 import static org.lwjgl.opengl.GL32C.glGetIntegerv;
-import static org.lwjgl.opengl.GL32C.glGetVertexAttribi;
 import static org.lwjgl.opengl.GL32C.glIsEnabled;
 import static org.lwjgl.opengl.GL32C.glUseProgram;
 import static org.lwjgl.opengl.GL32C.glViewport;
@@ -84,7 +79,6 @@ final class GlState {
 
     // Vertex array state
     private static int boundVertexArray;
-    private static final boolean[] enabledVertexAttribArrays = new boolean[16];
 
     // Framebuffer states
     private static int boundDrawFramebuffer;
@@ -137,9 +131,6 @@ final class GlState {
 
         // Read vertex array state
         boundVertexArray = glGetInteger(GL_VERTEX_ARRAY_BINDING);
-        for (int i = 0; i < enabledVertexAttribArrays.length; i++) {
-            enabledVertexAttribArrays[i] = glGetVertexAttribi(i, GL_VERTEX_ATTRIB_ARRAY_ENABLED) == GL_TRUE;
-        }
 
         // Read framebuffer states
         boundDrawFramebuffer = glGetInteger(GL_DRAW_FRAMEBUFFER_BINDING);
@@ -332,24 +323,7 @@ final class GlState {
     }
 
     /**
-     * Enables or disables a vertex attribute array.
-     *
-     * @param index   The attribute index
-     * @param enabled Whether the attribute should be enabled
-     */
-    public static void enableVertexAttribArray(int index, boolean enabled) {
-        if (index >= 0 && index < enabledVertexAttribArrays.length && enabled != enabledVertexAttribArrays[index]) {
-            if (enabled) {
-                glEnableVertexAttribArray(index);
-            } else {
-                glDisableVertexAttribArray(index);
-            }
-            enabledVertexAttribArrays[index] = enabled;
-        }
-    }
-
-    /**
-     * A record class representing a snapshot of the OpenGL state.
+     * A snapshot of the OpenGL state.
      */
     public record StateSnapshot(
             int viewportX, int viewportY, int viewportWidth, int viewportHeight,
@@ -358,16 +332,9 @@ final class GlState {
             int blendSrcRGB, int blendDstRGB, int blendSrcAlpha, int blendDstAlpha,
             int currentProgram,
             int boundTexture2D, int activeTextureUnit,
-            int boundVertexArray, boolean[] enabledVertexAttribArrays,
+            int boundVertexArray,
             int boundDrawFramebuffer, int boundReadFramebuffer,
-            int boundElementArrayBuffer, int boundArrayBuffer) {
-        /**
-         * Creates a copy of the enabledVertexAttribArrays to avoid sharing arrays.
-         */
-        public StateSnapshot {
-            enabledVertexAttribArrays = enabledVertexAttribArrays.clone();
-        }
-    }
+            int boundElementArrayBuffer, int boundArrayBuffer) {}
 
     /**
      * Creates a snapshot of the current OpenGL state.
@@ -382,7 +349,7 @@ final class GlState {
                 blendSrcRGB, blendDstRGB, blendSrcAlpha, blendDstAlpha,
                 currentProgram,
                 boundTexture2D, activeTextureUnit,
-                boundVertexArray, enabledVertexAttribArrays.clone(),
+                boundVertexArray,
                 boundDrawFramebuffer, boundReadFramebuffer,
                 boundElementArrayBuffer, boundArrayBuffer);
     }
@@ -415,10 +382,5 @@ final class GlState {
         }
         bindElementArrayBuffer(snapshot.boundElementArrayBuffer);
         bindArrayBuffer(snapshot.boundArrayBuffer);
-
-        // Apply vertex attribute array states
-        for (int i = 0; i < snapshot.enabledVertexAttribArrays.length; i++) {
-            enableVertexAttribArray(i, snapshot.enabledVertexAttribArrays[i]);
-        }
     }
 }

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleBufferBuilder.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/SimpleBufferBuilder.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.fml.earlydisplay;
 
+import static org.lwjgl.opengl.GL20C.glEnableVertexAttribArray;
 import static org.lwjgl.opengl.GL32C.*;
 
 import java.io.Closeable;
@@ -504,16 +505,7 @@ public class SimpleBufferBuilder implements Closeable {
          */
         public void enable() {
             for (int i = 0; i < types.length; i++) {
-                GlState.enableVertexAttribArray(i, true);
-            }
-        }
-
-        /**
-         * Disables the vertex attributes this format contains.
-         */
-        public void disable() {
-            for (int i = 0; i < types.length; i++) {
-                GlState.enableVertexAttribArray(i, false);
+                glEnableVertexAttribArray(i);
             }
         }
     }


### PR DESCRIPTION
This fixes:

- Reported incompatibility by NVidia NSight that we're using `glTexParameterIiv` to set `MIN_FILTER`, which is indeed incorrect/unintended since that is an "array" parameter while MIN_FILTER are simple enums. Changed this to use `glTexParameteri`.
- Removed state tracking of enabled vertex attrib bindings since those are stored within the bound VAO, so binding a VAO restores the attrib bindings already and no tracking is neccessary (and indeed causes GL warnings on some drivers if we try to query the bindings for VAO=0).