### PR TITLE
[RFC] Add conditional dependency capabilities to FML

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoader.java
@@ -102,7 +102,7 @@ public final class ModLoader {
         if (hasErrors()) {
             var loadingErrors = getLoadingErrors();
             for (var loadingError : loadingErrors) {
-                LOGGER.fatal(CORE, "Error during pre-loading phase: {}", FMLTranslations.translateIssueEnglish(loadingError), loadingError.cause());
+                LOGGER.fatal(CORE, "Error during pre-loading phase: {}\n{}", FMLTranslations.translateIssueEnglish(loadingError), loadingError.cause() != null ? loadingError.cause() : "");
             }
             cancelLoading(modList);
             throw new ModLoadingException(loadingIssues);

--- a/loader/src/main/java/net/neoforged/fml/loading/ModSorter.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/ModSorter.java
@@ -313,7 +313,7 @@ public class ModSorter {
                     "Missing or unsupported mandatory dependencies:\n{}",
                     missingVersions.stream()
                             .filter(mv -> mv.getType() == IModInfo.DependencyType.REQUIRED || mv.getType() == IModInfo.DependencyType.CONDITIONAL)
-                            .map(ver -> ver.getType() == IModInfo.DependencyType.CONDITIONAL ? formatConditionalDependencyError(ver, modVersions) : formatDependencyError(ver, modVersions))
+                            .map(ver -> formatDependencyError(ver, modVersions))
                             .collect(Collectors.joining("\n")));
         }
         if (missingVersions.size() - mandatoryMissing > 0) {
@@ -346,19 +346,6 @@ public class ModSorter {
                 dependency.getOwner().getModId(),
                 dependency.getVersionRange(),
                 installed != null ? installed.toString() : "[MISSING]");
-    }
-
-    private static String formatConditionalDependencyError(IModInfo.ModVersion dependency, Map<String, ArtifactVersion> modVersions) {
-        ArtifactVersion installedDep = modVersions.get(dependency.getModId());
-        List<String> installedConditions = dependency.getConditionalModIds().map(condIds -> condIds.stream().filter(modVersions::containsKey).collect(toList())).orElse(new ArrayList<>());
-        return String.format(
-                "\tMod ID: '%s', Requested by: '%s' because %s %s installed, Expected range: '%s', Actual version: '%s'",
-                dependency.getModId(),
-                dependency.getOwner().getModId(),
-                String.join(", ", installedConditions),
-                installedConditions.size() > 1 ? "are" : "is",
-                dependency.getVersionRange(),
-                installedDep != null ? installedDep.toString() : "[MISSING]");
     }
 
     private static String formatIncompatibleDependencyError(IModInfo.ModVersion dependency, String type, Map<String, ArtifactVersion> modVersions) {

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -207,6 +207,7 @@ public class ModInfo implements IModInfo, IConfigurable {
         private final VersionRange versionRange;
         private final DependencyType type;
         private final Optional<String> reason;
+        private final Optional<List<String>> conditionalModIds;
         private final Ordering ordering;
         private final DependencySide side;
         private Optional<URL> referralUrl;
@@ -217,6 +218,7 @@ public class ModInfo implements IModInfo, IConfigurable {
                     .orElseThrow(() -> new InvalidModFileException("Missing required field modid in dependency", getOwningFile()));
             this.type = config.<String>getConfigElement("type")
                     .map(str -> str.toUpperCase(Locale.ROOT)).map(DependencyType::valueOf).orElse(DependencyType.REQUIRED);
+            this.conditionalModIds = config.getConfigElement("conditionalModIds");
             this.reason = config.<String>getConfigElement("reason");
             this.versionRange = config.<String>getConfigElement("versionRange")
                     .map(MavenVersionAdapter::createFromVersionSpec)
@@ -244,6 +246,11 @@ public class ModInfo implements IModInfo, IConfigurable {
         @Override
         public DependencyType getType() {
             return type;
+        }
+
+        @Override
+        public Optional<List<String>> getConditionalModIds() {
+            return conditionalModIds;
         }
 
         @Override

--- a/loader/src/main/java/net/neoforged/neoforgespi/language/IModInfo.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/language/IModInfo.java
@@ -85,7 +85,7 @@ public interface IModInfo {
     }
 
     enum DependencyType {
-        REQUIRED, OPTIONAL,
+        REQUIRED, OPTIONAL, CONDITIONAL,
         /**
          * Prevents the game from loading if the dependency is loaded.
          */
@@ -93,7 +93,7 @@ public interface IModInfo {
         /**
          * Shows a warning if the dependency is loaded.
          */
-        DISCOURAGED
+        DISCOURAGED;
     }
 
     interface ModVersion {
@@ -103,9 +103,11 @@ public interface IModInfo {
 
         DependencyType getType();
 
+        Optional<List<String>> getConditionalModIds();
+
         /**
          * {@return the reason of this dependency}
-         * Only displayed if the type is either {@link DependencyType#DISCOURAGED} or {@link DependencyType#INCOMPATIBLE}
+         * Only displayed if the type is either {@link DependencyType#DISCOURAGED}, {@link DependencyType#INCOMPATIBLE}, or {@link DependencyType#CONDITIONAL}
          */
         Optional<String> getReason();
 

--- a/loader/src/main/resources/lang/en_us.json
+++ b/loader/src/main/resources/lang/en_us.json
@@ -14,6 +14,7 @@
   "fml.modloadingissue.javafml.dangling_entrypoint": "File {2} contains mod entrypoint class §6{1}§r for mod with id §e{0}§r, which does not exist or is not in the same file.\nDid you forget to update the mod id in the entrypoint?",
   "fml.modloadingissue.missingdependency": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r\n§7Currently, §6{0}§r§7 is §o{3,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{4,optional,§7Reason for the dependency: §r}",
   "fml.modloadingissue.missingdependency.optional": "Mod §e{1}§r only supports §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}",
+  "fml.modloadingissue.missingdependency.conditional": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r when §6{3}§r is installed\n§7Currently, §6{0}§r§7 is §o{4,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{5,optional,§7Reason for the dependency: §r}",
   "fml.modloadingissue.incompatiblemod": "Mod §e{1}§r is §cincompatible§r with §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}§r\n§7The reason is:§r §o{4,i18ntranslate}§r",
   "fml.modloadingissue.discouragedmod": "Mod §e{1}§r §ddiscourages§r the use of §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}§r\n§7The reason is:§r §o{4,i18ntranslate}§r",
   "fml.modloadingissue.discouragedmod.proceed": "Proceed at your own risk",

--- a/loader/src/main/resources/lang/en_us.json
+++ b/loader/src/main/resources/lang/en_us.json
@@ -14,7 +14,7 @@
   "fml.modloadingissue.javafml.dangling_entrypoint": "File {2} contains mod entrypoint class §6{1}§r for mod with id §e{0}§r, which does not exist or is not in the same file.\nDid you forget to update the mod id in the entrypoint?",
   "fml.modloadingissue.missingdependency": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r\n§7Currently, §6{0}§r§7 is §o{3,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{4,optional,§7Reason for the dependency: §r}",
   "fml.modloadingissue.missingdependency.optional": "Mod §e{1}§r only supports §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}",
-  "fml.modloadingissue.missingdependency.conditional": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r when §6{3}§r is installed\n§7Currently, §6{0}§r§7 is §o{4,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{5,optional,§7Reason for the dependency: §r}",
+  "fml.modloadingissue.missingdependency.conditional": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r when {3}§r is installed\n§7Currently, §6{0}§r§7 is §o{4,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{5,optional,§7Reason for the dependency: §r}",
   "fml.modloadingissue.incompatiblemod": "Mod §e{1}§r is §cincompatible§r with §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}§r\n§7The reason is:§r §o{4,i18ntranslate}§r",
   "fml.modloadingissue.discouragedmod": "Mod §e{1}§r §ddiscourages§r the use of §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}§r\n§7The reason is:§r §o{4,i18ntranslate}§r",
   "fml.modloadingissue.discouragedmod.proceed": "Proceed at your own risk",

--- a/loader/src/main/resources/lang/en_us.json
+++ b/loader/src/main/resources/lang/en_us.json
@@ -14,7 +14,7 @@
   "fml.modloadingissue.javafml.dangling_entrypoint": "File {2} contains mod entrypoint class §6{1}§r for mod with id §e{0}§r, which does not exist or is not in the same file.\nDid you forget to update the mod id in the entrypoint?",
   "fml.modloadingissue.missingdependency": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r\n§7Currently, §6{0}§r§7 is §o{3,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{4,optional,§7Reason for the dependency: §r}",
   "fml.modloadingissue.missingdependency.optional": "Mod §e{1}§r only supports §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}",
-  "fml.modloadingissue.missingdependency.conditional": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r when {3}§r is installed\n§7Currently, §6{0}§r§7 is §o{4,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{5,optional,§7Reason for the dependency: §r}",
+  "fml.modloadingissue.missingdependency.conditional": "Mod §e{1}§r requires §6{0}§r §o{2,vr}§r when one of the following is installed: {3}§r\n§7Currently, §6{0}§r§7 is §o{4,i18n,fml.messages.artifactversion.ornotinstalled}§r\n{5,optional,§7Reason for the dependency: §r}",
   "fml.modloadingissue.incompatiblemod": "Mod §e{1}§r is §cincompatible§r with §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}§r\n§7The reason is:§r §o{4,i18ntranslate}§r",
   "fml.modloadingissue.discouragedmod": "Mod §e{1}§r §ddiscourages§r the use of §3{0}§r §o{2,vr}§r\n§7Currently, §3{0}§r§7 is §o{3}§r\n§7The reason is:§r §o{4,i18ntranslate}§r",
   "fml.modloadingissue.discouragedmod.proceed": "Proceed at your own risk",


### PR DESCRIPTION
This feature is mainly aimed at mods that acknowledge the presence of third-party compatibility mods and support their use.