### PR TITLE
Fix: no modid is logged when "Failed to validate feature bounds"

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoader.java
@@ -114,7 +114,7 @@ public final class ModLoader {
                 .toList();
 
         if (!failedBounds.isEmpty()) {
-            LOGGER.fatal(CORE, "Failed to validate feature bounds for mods: {}", failedBounds);
+            LOGGER.fatal(CORE, "Failed to validate feature bounds for mods: {}", failedBounds.stream().map(bound -> bound.visualizedInfo()).toList());
             for (var fb : failedBounds) {
                 loadingIssues.add(ModLoadingIssue.error("fml.modloadingissue.feature.missing", fb, ForgeFeature.featureValue(fb)).withAffectedMod(fb.modInfo()));
             }

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -201,6 +201,10 @@ public class ModInfo implements IModInfo, IConfigurable {
         }
     }
 
+    public String visualizedInfo() {
+        return "{modId=" + this.modId + ", displayName=" + this.displayName + "}"
+    }
+
     class ModVersion implements net.neoforged.neoforgespi.language.IModInfo.ModVersion {
         private IModInfo owner;
         private final String modId;

--- a/loader/src/main/java/net/neoforged/neoforgespi/locating/ForgeFeature.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/locating/ForgeFeature.java
@@ -68,6 +68,10 @@ public class ForgeFeature {
         public <T> T bound() {
             return (T) features.getOrDefault(featureName, MISSING).convertFromString(featureBound);
         }
+
+        public String visualizedInfo() {
+            return "{featureName=" + this.featureName + ", featureBound=" + this.featureBound + ", modInfo=" + this.modInfo.visualizedInfo() + "}"
+        }
     }
 
     /**


### PR DESCRIPTION
Currently, FML can not output which mod causes `Failed to validate feature bounds`. The only logged information is the address of the mod info:

![image](https://github.com/user-attachments/assets/b103e1c9-959f-41d9-8e2a-47c67a40891d)

