### PR TITLE
Increase log verbosity of refused event dispatch messages

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/ModLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/ModLoader.java
@@ -330,7 +330,7 @@ public final class ModLoader {
 
     public static <T extends Event & IModBusEvent> void runEventGenerator(Function<ModContainer, T> generator) {
         if (hasErrors()) {
-            LOGGER.error("Cowardly refusing to send event generator to a broken mod state");
+            LOGGER.trace("Cowardly refusing to send event generator to a broken mod state");
             return;
         }
 
@@ -349,7 +349,7 @@ public final class ModLoader {
 
     public static <T extends Event & IModBusEvent> void postEvent(T e) {
         if (hasErrors()) {
-            LOGGER.error("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
+            LOGGER.trace("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
             return;
         }
         for (EventPriority phase : EventPriority.values()) {
@@ -368,7 +368,7 @@ public final class ModLoader {
 
     public static <T extends Event & IModBusEvent> void postEventWithWrapInModOrder(T e, BiConsumer<ModContainer, T> pre, BiConsumer<ModContainer, T> post) {
         if (hasErrors()) {
-            LOGGER.error("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
+            LOGGER.trace("Cowardly refusing to send event {} to a broken mod state", e.getClass().getName());
             return;
         }
         for (EventPriority phase : EventPriority.values()) {


### PR DESCRIPTION
Usually, when a modder has an error in their code, we will spam out a bunch of these errors because the mod state is broken.

However, if it were a true error, you would expect all of our dispatches to be guarded with something to the effect of `if (!bus.isInErrorState()) { bus.dispatchEvent(...); }` which is not the case.

Because of this, it's noise at best and should be warn at highest. Instead, I chose trace because it's TYPICALLY only of use to Neo devs, or more involved debugging from modders.