### PR TITLE
Make ModLifecycleEvent#getContainer public

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/event/lifecycle/ModLifecycleEvent.java
+++ b/loader/src/main/java/net/neoforged/fml/event/lifecycle/ModLifecycleEvent.java
@@ -23,11 +23,6 @@ public abstract class ModLifecycleEvent extends Event implements IModBusEvent {
         this.container = container;
     }
 
-    public final String description() {
-        String cn = getClass().getName();
-        return cn.substring(cn.lastIndexOf('.') + 1);
-    }
-
     public Stream<InterModComms.IMCMessage> getIMCStream() {
         return InterModComms.getMessages(this.container.getModId());
     }
@@ -36,12 +31,7 @@ public abstract class ModLifecycleEvent extends Event implements IModBusEvent {
         return InterModComms.getMessages(this.container.getModId(), methodFilter);
     }
 
-    ModContainer getContainer() {
+    public ModContainer getContainer() {
         return this.container;
-    }
-
-    @Override
-    public String toString() {
-        return description();
     }
 }


### PR DESCRIPTION
It can be useful to access the mod container, and there's really no reason not to expose it.

Also removed the very weird and unnecessary implementation of `toString`.