### PR TITLE
Avoid leaking JarContents when checking if jar should load in service layer

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/TransformerDiscovererConstants.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/TransformerDiscovererConstants.java
@@ -52,7 +52,7 @@ public final class TransformerDiscovererConstants {
             try {
                 contents.close();
             } catch (IOException e) {
-                LOGGER.error("Could not close JarContents", e);
+                LOGGER.error("Could not close JarContents {}", paths, e);
             }
         }
     }


### PR DESCRIPTION
Fixes #289. This code is somewhat convoluted because `JarContents` is not `AutoCloseable`, and does not override `close` to remove the checked exception declaration. To avoid duplicating the logic, I made the single-path method delegate to the multi-path method. This should be fine as that code should not be a hotspot for allocations.

The fix should be backported to the 1.21.1 version of FML if possible as quite a lot of heap space is wasted by this leak.