### PR TITLE
Remove the juggling of GLFW context of ELS when closed

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/LoadingScreenRenderer.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/LoadingScreenRenderer.java
@@ -259,9 +259,6 @@ public class LoadingScreenRenderer implements AutoCloseable {
 
     @Override
     public void close() {
-        GLFW.glfwMakeContextCurrent(glfwWindow);
-        GL.createCapabilities();
-
         theme.close();
         for (var element : elements) {
             element.close();
@@ -269,9 +266,6 @@ public class LoadingScreenRenderer implements AutoCloseable {
         framebuffer.close();
         buffer.close();
         SimpleBufferBuilder.destroy();
-
-        GLFW.glfwMakeContextCurrent(0);
-        GL.setCapabilities(null);
     }
 
     public int getFramebufferTextureId() {


### PR DESCRIPTION
`DisplayWindow` is closed within the main minecraft render thread, therefore there is no need to try to coup back context in `LoadingScreenRenderer#close` and then give it up, as this also causes the render thread to lose context and requires it to grab it again and reinitialise GL capabilities