### PR TITLE
Re-Enable JCC

### DIFF
--- a/.github/workflows/build-prs.yml
+++ b/.github/workflows/build-prs.yml
@@ -22,5 +22,5 @@ jobs:
       java: 21
       # --info allows seeing STDOUT of tests
       gradle_tasks: check --info
-      jar_compatibility: false # Temporarily disabled for FML 9.0 initial release
+      jar_compatibility: true
       graphics_environment: true


### PR DESCRIPTION
Now that FML 9.0 is released, we can re-enable this task.