### PR TITLE
Don't publish tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,15 +87,17 @@ subprojects { subProject ->
         archives sourcesJar
     }
 
-    publishing {
-        publications {
-            maven(MavenPublication) {
-                from components.java
+    if (project.name != 'tests' && project.name != 'testlib') {
+        publishing {
+            publications {
+                maven(MavenPublication) {
+                    from components.java
+                }
             }
-        }
 
-        repositories {
-            maven gradleutils.publishingMaven
+            repositories {
+                maven gradleutils.publishingMaven
+            }
         }
     }
 


### PR DESCRIPTION
Disable publication of the tests and testlib subprojects.
They are solely meant for internal consumption.