### PR TITLE
Fix issues with development environment

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 gradleutils_version=5.0.1
 
-test_neoforge_version=21.6.6-beta
-test_minecraft_version=1.21.6
+test_neoforge_version=21.7.3-beta
+test_minecraft_version=1.21.7
 
 mergetool_version=2.0.0
 accesstransformers_version=11.0.2

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,8 +8,8 @@ pluginManagement {
     }
 
     plugins {
-        id 'net.neoforged.moddev' version '2.0.95'
-        id 'net.neoforged.moddev.repositories' version '2.0.95'
+        id 'net.neoforged.moddev' version '2.0.97'
+        id 'net.neoforged.moddev.repositories' version '2.0.97'
     }
 }
 

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -91,6 +91,9 @@ runConfigurations {
 
 // Since the neoforge-dependencies use strict resolution, we're kinda lost and have to force.
 configurations.configureEach {
+    if (it.name.startsWith('neoFormRuntime')) {
+        return
+    }
     resolutionStrategy.dependencySubstitution {
         substitute module("net.neoforged.fancymodloader:loader") using project(":loader")
         substitute module("net.neoforged.fancymodloader:earlydisplay") using project(":earlydisplay")

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -54,6 +54,8 @@ runConfigurations {
         dependencies {
             classpath project(":earlydisplay")
             classpath project(":loader")
+            classpath project(":securejarhandler")
+            classpath project(":bootstraplauncher")
             classpath("net.neoforged:minecraft-dependencies:$test_minecraft_version") {
                 exclude group: 'org.ow2.asm' // Conflicting strict requirements on ASM version
             }
@@ -97,5 +99,7 @@ configurations.configureEach {
     resolutionStrategy.dependencySubstitution {
         substitute module("net.neoforged.fancymodloader:loader") using project(":loader")
         substitute module("net.neoforged.fancymodloader:earlydisplay") using project(":earlydisplay")
+        substitute module("net.neoforged.fancymodloader:securejarhandler") using project(":securejarhandler")
+        substitute module("net.neoforged.fancymodloader:bootstraplauncher") using project(":bootstraplauncher")
     }
 }


### PR DESCRIPTION
This fixes several issues that currently cause pain in an FML development environment:
- the `:loader:jar` task is triggered on IDE sync, as it is requested by MDG/NFRT stuff in `:tests`; this leads to the project being impossible to import if it has errors.
- the neoforge version is too old an expects `RuntimeDistCleaner`, meaning that the `:tests` test cannot be ran.
- the `securejarhandler` and `bootstraplauncher` modules are not replaced in the `:tests` project.