### PR TITLE
Remove unused securityStatus from ModFile

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFile.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFile.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -59,7 +58,6 @@ public class ModFile implements IModFile {
     private List<Path> accessTransformers;
 
     public static final Attributes.Name TYPE = new Attributes.Name("FMLModType");
-    private SecureJar.Status securityStatus;
 
     public ModFile(SecureJar jar, final ModFileInfoParser parser, ModFileDiscoveryAttributes attributes) {
         this(jar, parser, parseType(jar), attributes);
@@ -141,10 +139,9 @@ public class ModFile implements IModFile {
     }
 
     public void scanFile(Consumer<Path> pathConsumer) {
-        final Function<Path, SecureJar.Status> status = p -> getSecureJar().verifyPath(p);
         var rootPath = getSecureJar().getRootPath();
         try (Stream<Path> files = Files.find(rootPath, Integer.MAX_VALUE, (p, a) -> p.getNameCount() > 0 && p.getFileName().toString().endsWith(".class"))) {
-            setSecurityStatus(files.peek(pathConsumer).map(status).reduce((s1, s2) -> SecureJar.Status.values()[Math.min(s1.ordinal(), s2.ordinal())]).orElse(SecureJar.Status.INVALID));
+            files.forEach(pathConsumer);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to scan " + rootPath, e);
         }
@@ -221,11 +218,6 @@ public class ModFile implements IModFile {
     @Override
     public IModFileInfo getModFileInfo() {
         return modFileInfo;
-    }
-
-    @Override
-    public void setSecurityStatus(final SecureJar.Status status) {
-        this.securityStatus = status;
     }
 
     public ArtifactVersion getJarVersion() {

--- a/loader/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/locating/IModFile.java
@@ -104,14 +104,6 @@ public interface IModFile {
     SecureJar getSecureJar();
 
     /**
-     * Sets the security status after verification of the mod file has been concluded.
-     * The security status is only determined if the jar is to be loaded into the runtime.
-     *
-     * @param status The new status.
-     */
-    void setSecurityStatus(SecureJar.Status status);
-
-    /**
      * Returns a list of all mods located inside this jar.
      * <p>
      * If this method returns any entries then {@link #getType()} has to return {@link Type#MOD},


### PR DESCRIPTION
The field it sets is never read.

This is technically a breaking change too, since the setter was a public API, but should never have been called publicly either.