### PR TITLE
Fix metadata for jars without packages

### DIFF
--- a/securejarhandler/src/test/java/cpw/mods/jarhandling/impl/JarMetadataTest.java
+++ b/securejarhandler/src/test/java/cpw/mods/jarhandling/impl/JarMetadataTest.java
@@ -54,12 +54,17 @@ public class JarMetadataTest {
 
         @Test
         void testPackagesAreScannedIfNotDeclaredInModuleInfo() throws IOException {
+            var descriptor = ModuleDescriptor.newModule("test_module")
+                    .version("1.0")
+                    .exports("exported_package")
+                    .build();
             var metadata = getJarMetadata("test.jar", builder -> builder
+                    .addBinaryFile("exported_package/SomeClass.class", new byte[] {})
                     .addBinaryFile("somepackage/SomeClass.class", new byte[] {})
-                    .withModuleInfo(ModuleDescriptor.newModule("test_module").version("1.0").build()));
+                    .addBinaryFile("module-info.class", ModuleInfoWriter.toByteArrayWithoutPackages(descriptor)));
 
             // It should find the package, even if it wasn't declared
-            assertEquals(Set.of("somepackage"), metadata.descriptor().packages());
+            assertEquals(Set.of("somepackage", "exported_package"), metadata.descriptor().packages());
         }
 
         @Test

--- a/testlib/src/main/java/net/neoforged/fml/testlib/ModuleInfoWriter.java
+++ b/testlib/src/main/java/net/neoforged/fml/testlib/ModuleInfoWriter.java
@@ -16,7 +16,19 @@ import org.objectweb.asm.Opcodes;
 public final class ModuleInfoWriter {
     private ModuleInfoWriter() {}
 
+    /**
+     * Writes a module-info.class, but omits the package list attribute (which is optional), to test
+     * our code for reconstructing it.
+     */
+    public static byte[] toByteArrayWithoutPackages(ModuleDescriptor descriptor) {
+        return toByteArray(descriptor, false);
+    }
+
     public static byte[] toByteArray(ModuleDescriptor descriptor) {
+        return toByteArray(descriptor, true);
+    }
+
+    private static byte[] toByteArray(ModuleDescriptor descriptor, boolean withPackages) {
         ClassWriter cw = new ClassWriter(0);
         String internalName = "module-info";
         cw.visit(Opcodes.V11, Opcodes.ACC_MODULE, internalName, null, null, null);
@@ -36,7 +48,9 @@ public final class ModuleInfoWriter {
         descriptor.provides().forEach(prov -> mv.visitProvide(toBinaryName(prov.service()),
                 prov.providers().stream().map(ModuleInfoWriter::toBinaryName).toArray(String[]::new)));
 
-        descriptor.packages().forEach(p -> mv.visitPackage(toBinaryName(p)));
+        if (withPackages) {
+            descriptor.packages().forEach(p -> mv.visitPackage(toBinaryName(p)));
+        }
 
         mv.visitEnd();
         cw.visitEnd();


### PR DESCRIPTION
Sadly the previous approach of #320 didn't quite work if the module had no package listing, but actual packages in the descriptor, since Java would validate the return value of the package finder (In our case `Set.of()`). Adapted the test to catch this case too.

We're not reading the descriptor twice. Once without a package finder purely for name + version, and another time (lazily), with the package finder. Java will then decide whether it needs to be called or not (still applying the optimization of not scanning for packages if we don't have to).
