### PR TITLE
Align package scanning more with how the JDK does it.

### DIFF
--- a/securejarhandler/src/main/java/cpw/mods/jarhandling/JarContents.java
+++ b/securejarhandler/src/main/java/cpw/mods/jarhandling/JarContents.java
@@ -37,7 +37,7 @@ public interface JarContents extends Closeable {
 
     /**
      * {@return all the packages in the jar}
-     * (Every folder containing a {@code .class} file is considered a package.)
+     * (Every folder containing a file is considered a package if it is a valid package name, excluding {@code /assets} and {@code /data}.)
      */
     Set<String> getPackages();
 

--- a/securejarhandler/src/main/java/cpw/mods/jarhandling/JarContents.java
+++ b/securejarhandler/src/main/java/cpw/mods/jarhandling/JarContents.java
@@ -37,7 +37,7 @@ public interface JarContents extends Closeable {
 
     /**
      * {@return all the packages in the jar}
-     * (Every folder containing a file is considered a package if it is a valid package name, excluding {@code /assets} and {@code /data}.)
+     * (Every folder containing a file is considered a package if it is a valid package name.)
      */
     Set<String> getPackages();
 

--- a/securejarhandler/src/main/java/cpw/mods/jarhandling/impl/JlsConstants.java
+++ b/securejarhandler/src/main/java/cpw/mods/jarhandling/impl/JlsConstants.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package cpw.mods.jarhandling.impl;
+
+import java.util.Set;
+
+final class JlsConstants {
+    // https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9
+    static final Set<String> RESERVED_KEYWORDS = Set.of(
+            "abstract",
+            "assert",
+            "boolean",
+            "break",
+            "byte",
+            "case",
+            "catch",
+            "char",
+            "class",
+            "const",
+            "continue",
+            "default",
+            "do",
+            "double",
+            "else",
+            "enum",
+            "extends",
+            "final",
+            "finally",
+            "float",
+            "for",
+            "goto",
+            "if",
+            "implements",
+            "import",
+            "instanceof",
+            "int",
+            "interface",
+            "long",
+            "native",
+            "new",
+            "package",
+            "private",
+            "protected",
+            "public",
+            "return",
+            "short",
+            "static",
+            "strictfp",
+            "super",
+            "switch",
+            "synchronized",
+            "this",
+            "throw",
+            "throws",
+            "transient",
+            "try",
+            "void",
+            "volatile",
+            "while",
+            // Not really keywords, but "boolean literals"
+            "true",
+            "false",
+            // Not really a keyword, but the "null literal"
+            "null",
+            "_");
+
+    // Same as jdk.internal.module.Checks.isJavaIdentifier
+    public static boolean isJavaIdentifier(String str) {
+        if (str.isEmpty() || RESERVED_KEYWORDS.contains(str)) {
+            return false;
+        }
+
+        // This iterates over the Unicode code points instead of UTF-16 characters
+        for (var i = 0; i < str.length();) {
+            int codePoint = Character.codePointAt(str, i);
+
+            if (i == 0 && !Character.isJavaIdentifierStart(codePoint)
+                    || !Character.isJavaIdentifierPart(codePoint)) {
+                return false;
+            }
+
+            i += Character.charCount(codePoint);
+        }
+
+        return true;
+    }
+
+    private JlsConstants() {}
+}

--- a/securejarhandler/src/test/java/cpw/mods/jarhandling/impl/JarMetadataTest.java
+++ b/securejarhandler/src/test/java/cpw/mods/jarhandling/impl/JarMetadataTest.java
@@ -61,10 +61,14 @@ public class JarMetadataTest {
             var metadata = getJarMetadata("test.jar", builder -> builder
                     .addBinaryFile("exported_package/SomeClass.class", new byte[] {})
                     .addBinaryFile("somepackage/SomeClass.class", new byte[] {})
+                    .addBinaryFile("resources/alsocount/resource.txt", new byte[] {})
+                    .addBinaryFile("META-INF/Ignored.class", new byte[] {})
+                    .addBinaryFile("not/while/package/Ignored.class", new byte[] {})
+                    .addBinaryFile("9/notanidentifier/Ignored.class", new byte[] {})
                     .addBinaryFile("module-info.class", ModuleInfoWriter.toByteArrayWithoutPackages(descriptor)));
 
             // It should find the package, even if it wasn't declared
-            assertEquals(Set.of("somepackage", "exported_package"), metadata.descriptor().packages());
+            assertEquals(Set.of("somepackage", "exported_package", "resources.alsocount"), metadata.descriptor().packages());
         }
 
         @Test


### PR DESCRIPTION
Which results in the following:

- Packages that contain resources are picked up
- Packages that are not valid Java package names are ignored (every path segment needs to be a valid Java identifier).

This fixes issues with creating module metadata for LWJGL native modules, where the module-info.class has no package list, but exports a package called `windows.x64.[...]` which only contains the `.dll` but no `.class` file.