### PR TITLE
Make `ModConfig.getFullPath` nullable

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
@@ -69,11 +69,7 @@ public final class ModConfig {
      */
     @Nullable
     public Path getFullPath() {
-        if (this.loadedConfig != null && loadedConfig.path() != null) {
-            return loadedConfig.path();
-        } else {
-            return null;
-        }
+        return loadedConfig != null ? loadedConfig.path() : null;
     }
 
     void setConfig(@Nullable LoadedConfig loadedConfig, Function<ModConfig, ModConfigEvent> eventConstructor) {

--- a/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
@@ -61,12 +61,18 @@ public final class ModConfig {
         return loadedConfig;
     }
 
-    // TODO: remove from public API?
+    /**
+     * Get the file path of the currently loaded config.
+     *
+     * @return The config's path. Will return {@code null} if the config is not currently loaded, or was loaded
+     *         from memory rather than from a file.
+     */
+    @Nullable
     public Path getFullPath() {
         if (this.loadedConfig != null && loadedConfig.path() != null) {
             return loadedConfig.path();
         } else {
-            throw new IllegalStateException("Cannot call getFullPath() on non-file config " + this.loadedConfig + " at path " + getFileName());
+            return null;
         }
     }
 


### PR DESCRIPTION
Closes #236. To quote from that issue:

I currently use `ModConfig.getFullPath` in order to read another file adjacent to the main config file that contains secrets (you don't want them in the main config file, as they get synced over the network).

However, there currently isn't a way to determine whether the config file is being synced from disk over the network. As a result, there's no way to tell if `getFullPath` will throw, and so you have to [try/catch the error instead](https://github.com/cc-tweaked/CC-Tweaked/blob/d697c47b8023ade33dda2198e34adf187e4ea9fc/projects/forge/src/main/java/dan200/computercraft/ComputerCraft.java#L179-L184).

With this change, one can remove the `try`/`catch`, which makes this pattern much nicer!