### PR TITLE
Add tests that check when and which ATs are applied

### DIFF
--- a/loader/src/test/java/net/neoforged/fml/loading/AccessTransformerTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/AccessTransformerTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
 package net.neoforged.fml.loading;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
This arose from the question whether game libraries have their default AT applied or not.

Answer: They don't.