### PR TITLE
Raise minimum OpenGL version to 3.3 as Minecraft 1.21.9 did

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -328,7 +328,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
         glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_API);
         glfwWindowHint(GLFW_CONTEXT_CREATION_API, GLFW_NATIVE_CONTEXT_API);
         glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 2);
+        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
         glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
         glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
         // End of flags copied from Vanilla Minecraft


### PR DESCRIPTION
Minecraft 1.21.9 increased the minimum OpenGL version to 3.3 Core Profile.