### PR TITLE
Fix log4j2 logging service package

### DIFF
--- a/loader/src/main/resources/log4j2.component.properties
+++ b/loader/src/main/resources/log4j2.component.properties
@@ -1,1 +1,1 @@
-Log4jContextSelector=net.neoforged.fml.log.MLClassLoaderContextSelector
+Log4jContextSelector=net.neoforged.fml.logging.MLClassLoaderContextSelector


### PR DESCRIPTION
IntelliJ somehow missed it during the rename from log -> logging.