### PR TITLE
Add a method for mods to add their own close callbacks

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
@@ -226,7 +226,7 @@ public final class FMLLoader implements AutoCloseable {
             try {
                 ownedResource.close();
             } catch (Exception e) {
-                LOGGER.error("Failed to close resource {}", ownedResource, e);
+                LOGGER.error("Failed to close resource {} owned by FMLLoader", ownedResource, e);
             }
         }
         ownedResources.clear();

--- a/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
@@ -110,6 +110,10 @@ public final class FMLLoader implements AutoCloseable {
      * will be closed alongside the loader.
      */
     private final List<AutoCloseable> ownedResources = new ArrayList<>();
+    /**
+     * Additional callbacks that will be called when this loader is about to close.
+     */
+    private final List<Runnable> closeCallbacks = new ArrayList<>();
     private final ProgramArgs programArgs;
 
     private LanguageProviderLoader languageProviderLoader;
@@ -180,9 +184,27 @@ public final class FMLLoader implements AutoCloseable {
         return loadingModList.getPackageIndex().get(packageName);
     }
 
+    /**
+     * Adds a callback that will be called when this loader is about to close, but all mod files are still open,
+     * so class-loading will still succeed.
+     */
+    public void addCloseCallback(Runnable callback) {
+        closeCallbacks.add(callback);
+    }
+
     @Override
     public void close() {
         LOGGER.info("Closing FML Loader {}", Integer.toHexString(System.identityHashCode(this)));
+
+        for (var closeCallback : closeCallbacks) {
+            try {
+                closeCallback.run();
+            } catch (Exception e) {
+                LOGGER.error("Failed to run mod-supplied close callback {}", closeCallback, e);
+            }
+        }
+        closeCallbacks.clear();
+
         if (loadingModList != null) {
             for (var modFile : loadingModList.getModFiles()) {
                 modFile.getFile().close();
@@ -204,7 +226,7 @@ public final class FMLLoader implements AutoCloseable {
             try {
                 ownedResource.close();
             } catch (Exception e) {
-                LOGGER.error("Failed to close resource {} owned by FMLLoader", ownedResource, e);
+                LOGGER.error("Failed to close resource {}", ownedResource, e);
             }
         }
         ownedResources.clear();

--- a/loader/src/test/java/net/neoforged/fml/loading/LauncherTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/LauncherTest.java
@@ -157,7 +157,6 @@ public abstract class LauncherTest {
         actualClasspath.addAll(additionalClassPath);
 
         var previousCl = Thread.currentThread().getContextClassLoader();
-        URLClassLoader cl = null;
         if (!actualClasspath.isEmpty()) {
             var urls = actualClasspath.stream().map(path -> {
                 try {
@@ -166,8 +165,9 @@ public abstract class LauncherTest {
                     throw new RuntimeException(e);
                 }
             }).toArray(URL[]::new);
-            cl = new URLClassLoader(urls, getClass().getClassLoader());
+            var cl = new URLClassLoader(urls, getClass().getClassLoader());
             Thread.currentThread().setContextClassLoader(cl);
+            ownedResources.add(cl);
         }
 
         try {
@@ -183,9 +183,6 @@ public abstract class LauncherTest {
             loadMods();
             return result;
         } finally {
-            if (cl != null) {
-                cl.close();
-            }
             Thread.currentThread().setContextClassLoader(previousCl);
         }
     }


### PR DESCRIPTION
When FMLLoader closes, it will also close the underlying class-loader. If a mod registers a shutdown hook that means that additional classloading will fail. This mechanism will allow mods to register operations for when the loader is about to close.