### PR TITLE
Log early fatal exceptions to the console on the client too

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/startup/FatalErrorReporting.java
+++ b/loader/src/main/java/net/neoforged/fml/startup/FatalErrorReporting.java
@@ -53,9 +53,12 @@ public final class FatalErrorReporting {
         var issues = new ArrayList<ModLoadingIssue>();
         collectModLoadingIssues(t, issues);
 
-        if (issues.isEmpty()) {
-            t = unwrapException(t);
+        t = unwrapException(t);
 
+        // Print the error to the console too so that the stacktrace isn't lost
+        t.printStackTrace();
+
+        if (issues.isEmpty()) {
             if (t instanceof FatalStartupException e) {
                 var errorText = new StringBuilder(e.getMessage());
                 if (e.getCause() != null) {


### PR DESCRIPTION
Fixes https://github.com/neoforged/FancyModLoader/issues/409
In the above case, a mod's mixin plugin was throwing within `#getConfigs()`, method that was called when we attempted to load the Minecraft `Main` class. The stacktrace would be swallowed because the error wasn't logged along the way and simply wrapped into a fatal exception that would be caught at the end in `statup/Client`, exception that would only be shown to the user on-screen, and only the message, without a stacktrace.