### PR TITLE
Warn on mixin plugin classloads from the game layer

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/classloading/transformation/ClassProcessorSet.java
+++ b/loader/src/main/java/net/neoforged/fml/classloading/transformation/ClassProcessorSet.java
@@ -113,14 +113,14 @@ public final class ClassProcessorSet {
         return out;
     }
 
-    public void link(Function<ProcessorName, BytecodeProvider> bytecodeProviderLookup) {
+    public void link(Function<ProcessorName, BytecodeProvider> bytecodeProviderLookup, ClassLoader parentClassLoader) {
         if (linked) {
             throw new IllegalStateException("This set of class processors is already linked.");
         }
         linked = true;
 
         for (var processor : sortedProcessors) {
-            var context = new ClassProcessor.LinkContext(processors, bytecodeProviderLookup.apply(processor.name()));
+            var context = new ClassProcessor.LinkContext(processors, bytecodeProviderLookup.apply(processor.name()), parentClassLoader);
             processor.link(context);
         }
     }

--- a/loader/src/main/java/net/neoforged/fml/classloading/transformation/TransformingClassLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/classloading/transformation/TransformingClassLoader.java
@@ -38,7 +38,7 @@ public class TransformingClassLoader extends ModuleClassLoader {
         super("TRANSFORMER", configuration, parentLayers, parentClassLoader);
         this.classTransformer = new ClassTransformer(classProcessorSet, auditTrail);
         // The state of this class has to be set up fully before the processors are linked
-        classProcessorSet.link(processorName -> className -> buildTransformedClassNodeFor(className, processorName));
+        classProcessorSet.link(processorName -> className -> buildTransformedClassNodeFor(className, processorName), parentClassLoader);
     }
 
     @Override

--- a/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
@@ -107,6 +107,10 @@ public final class FMLLoader implements AutoCloseable {
      */
     private ClassLoader currentClassLoader;
     /**
+     * Supplies the current tail of the class-loader chain, excluding the game layer. It is safe for plugins to load classes from during transformation or the like.
+     */
+    private Supplier<ClassLoader> pluginClassLoader = () -> this.currentClassLoader;
+    /**
      * Resources owned by this loader, such as opened URL classloaders, which
      * will be closed alongside the loader.
      */
@@ -274,6 +278,10 @@ public final class FMLLoader implements AutoCloseable {
 
     public ClassLoader getCurrentClassLoader() {
         return currentClassLoader;
+    }
+
+    public ClassLoader getPluginClassLoader() {
+        return pluginClassLoader.get();
     }
 
     public ProgramArgs getProgramArgs() {
@@ -502,6 +510,8 @@ public final class FMLLoader implements AutoCloseable {
 
         gameLayer = layer;
         ownedResources.add(loader);
+        var parentClassLoader = currentClassLoader;
+        pluginClassLoader = () -> parentClassLoader;
         currentClassLoader = loader;
         Thread.currentThread().setContextClassLoader(loader);
         return loader;

--- a/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
@@ -107,10 +107,6 @@ public final class FMLLoader implements AutoCloseable {
      */
     private ClassLoader currentClassLoader;
     /**
-     * Supplies the current tail of the class-loader chain, excluding the game layer. It is safe for plugins to load classes from during transformation or the like.
-     */
-    private Supplier<ClassLoader> pluginClassLoader = () -> this.currentClassLoader;
-    /**
      * Resources owned by this loader, such as opened URL classloaders, which
      * will be closed alongside the loader.
      */
@@ -278,10 +274,6 @@ public final class FMLLoader implements AutoCloseable {
 
     public ClassLoader getCurrentClassLoader() {
         return currentClassLoader;
-    }
-
-    public ClassLoader getPluginClassLoader() {
-        return pluginClassLoader.get();
     }
 
     public ProgramArgs getProgramArgs() {
@@ -510,8 +502,6 @@ public final class FMLLoader implements AutoCloseable {
 
         gameLayer = layer;
         ownedResources.add(loader);
-        var parentClassLoader = currentClassLoader;
-        pluginClassLoader = () -> parentClassLoader;
         currentClassLoader = loader;
         Thread.currentThread().setContextClassLoader(loader);
         return loader;

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassProvider.java
@@ -16,7 +16,7 @@ import org.spongepowered.asm.service.IClassProvider;
  */
 class FMLClassProvider implements IClassProvider {
     private static final Logger LOGGER = LogManager.getLogger();
-    
+
     private final ClassLoader pluginClassLoader;
 
     FMLClassProvider(ClassLoader pluginClassLoader) {

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassProvider.java
@@ -7,12 +7,16 @@ package net.neoforged.fml.loading.mixin;
 
 import java.net.URL;
 import net.neoforged.fml.loading.FMLLoader;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.spongepowered.asm.service.IClassProvider;
 
 /**
  * Class provider for use under ModLauncher
  */
 class FMLClassProvider implements IClassProvider {
+    private static final Logger LOGGER = LogManager.getLogger();
+
     FMLClassProvider() {}
 
     @Override
@@ -23,12 +27,26 @@ class FMLClassProvider implements IClassProvider {
 
     @Override
     public Class<?> findClass(String name) throws ClassNotFoundException {
-        return Class.forName(name, true, FMLLoader.getCurrent().getCurrentClassLoader());
+        try {
+            return Class.forName(name, true, FMLLoader.getCurrent().getPluginClassLoader());
+        } catch (ClassNotFoundException e) {
+            warnOnDeprecatedTclPluginLoad(name);
+            return Class.forName(name, true, FMLLoader.getCurrent().getCurrentClassLoader());
+        }
     }
 
     @Override
     public Class<?> findClass(String name, boolean initialize) throws ClassNotFoundException {
-        return Class.forName(name, initialize, FMLLoader.getCurrent().getCurrentClassLoader());
+        try {
+            return Class.forName(name, initialize, FMLLoader.getCurrent().getPluginClassLoader());
+        } catch (ClassNotFoundException e) {
+            warnOnDeprecatedTclPluginLoad(name);
+            return Class.forName(name, initialize, FMLLoader.getCurrent().getCurrentClassLoader());
+        }
+    }
+
+    private static void warnOnDeprecatedTclPluginLoad(String name) {
+        LOGGER.error("Mixin attempted to load class {} from the transforming classloader. This behavior is deprecated and may not continue to work; mixin config plugins should be provided from FMLModType=LIBRARY jars instead.", name);
     }
 
     @Override

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassProvider.java
@@ -16,8 +16,12 @@ import org.spongepowered.asm.service.IClassProvider;
  */
 class FMLClassProvider implements IClassProvider {
     private static final Logger LOGGER = LogManager.getLogger();
+    
+    private final ClassLoader pluginClassLoader;
 
-    FMLClassProvider() {}
+    FMLClassProvider(ClassLoader pluginClassLoader) {
+        this.pluginClassLoader = pluginClassLoader;
+    }
 
     @Override
     @Deprecated
@@ -28,7 +32,7 @@ class FMLClassProvider implements IClassProvider {
     @Override
     public Class<?> findClass(String name) throws ClassNotFoundException {
         try {
-            return Class.forName(name, true, FMLLoader.getCurrent().getPluginClassLoader());
+            return Class.forName(name, true, pluginClassLoader);
         } catch (ClassNotFoundException e) {
             warnOnDeprecatedTclPluginLoad(name);
             return Class.forName(name, true, FMLLoader.getCurrent().getCurrentClassLoader());
@@ -38,7 +42,7 @@ class FMLClassProvider implements IClassProvider {
     @Override
     public Class<?> findClass(String name, boolean initialize) throws ClassNotFoundException {
         try {
-            return Class.forName(name, initialize, FMLLoader.getCurrent().getPluginClassLoader());
+            return Class.forName(name, initialize, pluginClassLoader);
         } catch (ClassNotFoundException e) {
             warnOnDeprecatedTclPluginLoad(name);
             return Class.forName(name, initialize, FMLLoader.getCurrent().getCurrentClassLoader());

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinClassProcessor.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinClassProcessor.java
@@ -34,6 +34,7 @@ public class FMLMixinClassProcessor implements ClassProcessor {
     @Override
     public void link(LinkContext context) {
         this.service.setBytecodeProvider(new FMLClassBytecodeProvider(context.bytecodeProvider(), this));
+        this.service.setClassProvider(new FMLClassProvider(context.pluginClassLoader()));
     }
 
     @Override

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinService.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinService.java
@@ -100,7 +100,7 @@ public class FMLMixinService implements IMixinService {
     public void setBytecodeProvider(@Nullable IClassBytecodeProvider bytecodeProvider) {
         this.bytecodeProvider = bytecodeProvider;
     }
-    
+
     public void setClassProvider(@Nullable IClassProvider classProvider) {
         this.classProvider = classProvider;
     }

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinService.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinService.java
@@ -100,6 +100,10 @@ public class FMLMixinService implements IMixinService {
     public void setBytecodeProvider(@Nullable IClassBytecodeProvider bytecodeProvider) {
         this.bytecodeProvider = bytecodeProvider;
     }
+    
+    public void setClassProvider(@Nullable IClassProvider classProvider) {
+        this.classProvider = classProvider;
+    }
 
     @Override
     public void offer(IMixinInternal internal) {
@@ -136,7 +140,7 @@ public class FMLMixinService implements IMixinService {
     @Override
     public IClassProvider getClassProvider() {
         if (this.classProvider == null) {
-            this.classProvider = new FMLClassProvider();
+            throw new IllegalStateException("Service initialisation incomplete, FMLMixinClassProcessor has not yet been linked");
         }
         return this.classProvider;
     }
@@ -144,7 +148,7 @@ public class FMLMixinService implements IMixinService {
     @Override
     public IClassBytecodeProvider getBytecodeProvider() {
         if (this.bytecodeProvider == null) {
-            throw new IllegalStateException("Service initialisation incomplete, launch plugin was not created");
+            throw new IllegalStateException("Service initialisation incomplete, FMLMixinClassProcessor has not yet been linked");
         }
         return this.bytecodeProvider;
     }

--- a/loader/src/main/java/net/neoforged/neoforgespi/transformation/ClassProcessor.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/transformation/ClassProcessor.java
@@ -221,12 +221,14 @@ public interface ClassProcessor {
      * The context provided to {@linkplain ClassProcessor class processors}
      * when they are linked with a bytecode source.
      * 
-     * @param processors       an immutable map of the processors that are being linked. The maps iteration order is the order in which the processors will be applied
-     * @param bytecodeProvider a provider to access class bytecode for other classes than the class that is being transformed
+     * @param processors        an immutable map of the processors that are being linked. The maps iteration order is the order in which the processors will be applied
+     * @param bytecodeProvider  a provider to access class bytecode for other classes than the class that is being transformed
+     * @param pluginClassLoader provides access to the classloader before the transforming classloader, for use in safely loading classes
      */
     record LinkContext(
             @Unmodifiable SequencedMap<ProcessorName, ClassProcessor> processors,
-            BytecodeProvider bytecodeProvider) {
+            BytecodeProvider bytecodeProvider,
+            ClassLoader pluginClassLoader) {
         @ApiStatus.Internal
         public LinkContext {}
     }


### PR DESCRIPTION
Long term, it would be a good idea to limit mixin plugins to be in `FMLModType=LIBRARY` jars and not be pulled up from the game layer during transformation.

I've mentioned this before but the fact that this works this way is the last major footgun in the transformation system and leads to a _lot_ of wacky behaviour. Most notably -- it's generally intended that part of the contract of a `ClassProcessor` is that its actions will only affect processors after it. This is not the case for mixin -- a `ClassProcessor`'s actions, even if that processor is after mixin, can affect what mixin does if it processes a class loaded (indirectly or directly) from a mixin plugin.

IMO it's a reasonable solution to limit mixin plugins (and anything mixin loads, for that matter) to LIBRARY -- after all, everything else out there that could be involved in transforming classes, that someone might write, would be loaded above the game layer (Mostly just `ClassProcessor`s now).

Last this was brought up there were worried about it causing extra complexity for people writing their own mixin plugins. My take is that this is (and ought to be!) a minority of modders -- even a minority of modders with mixins -- and is rarely needed for the things people say it is:
- configuring mixins with a config -- this can often be handled by a static block within the mixin itself, short-circuiting the logic depending on the config value. Cases where it can't exist, but they are the minority.
- enabling mixins only when certain mods are present -- there's already an option for this in the `mixins` block of your `neoforge.mods.toml`, no need for a mixin config plugin at all (and I've opened a PR to make sure that is documented).
- doing literally nothing -- a surprising number of mixin plugins out in the wild appear to be empty. Obviously, these can be removed.
- <anything more complex> probably involves details of transformation, so it should be assumed that if you're doing it you understand the game/library layer distinction and can write a LIBRARY jar for your config plugin.

Even a case that does require moving the plugin to a LIBRARY jar shouldn't be that difficult -- in fact, doing so [is already documented for MDG](https://github.com/neoforged/ModDevGradle/?tab=readme-ov-file#local-files).

This PR (a draft for now as I work out some details) would be the first step in this process, making mixin plugins loaded from the TCL during load log errors but allowing load to continue.

----------

For additional justification as to why this change should be made: currently, there is no entrypoint during which a classprocessor running after mixin may, before it needs to decide whether it is processing _any_ class, look at the mixin-transformed bytecode (which it has available to it, as it is running after mixin) of a particular vanilla class. Were you to do so in `handlesClass` (at the last possible moment that is), the first times that is queried would be for mixin plugin classes and you would be unable to see the mixin-transformed bytecode for anything as it is recursively hidden inside mixin transformation. This is bad; classprocessors should be independent from one another. They're well-ordered for a reason.