### PR TITLE
Fix check for active automatic rendering

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/LoadingScreenRenderer.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/LoadingScreenRenderer.java
@@ -190,6 +190,11 @@ public class LoadingScreenRenderer implements AutoCloseable {
     }
 
     public void stopAutomaticRendering() throws TimeoutException, InterruptedException {
+        if (this.automaticRendering.isCancelled()) {
+            // Auto-render was already canceled, likely by window takeover, and we got here from the early error display triggering after window takeover
+            return;
+        }
+
         this.automaticRendering.cancel(false);
         if (!renderLock.tryAcquire(5, TimeUnit.SECONDS)) {
             throw new TimeoutException();
@@ -236,7 +241,7 @@ public class LoadingScreenRenderer implements AutoCloseable {
         } catch (Throwable t) {
             LOGGER.error("Unexpected error while rendering the loading screen", t);
         } finally {
-            if (this.automaticRendering != null)
+            if (!this.automaticRendering.isCancelled())
                 glfwMakeContextCurrent(0); // we release the gl context IF we're running off the main thread
             renderLock.release();
             rendered = true;


### PR DESCRIPTION
This PR fixes the condition used to guard GL context reset in `LoadingScreenRenderer#renderToScreen()`. The field it checks is not nullable, never initialized to a null value and never re-assigned since it's final.
This issue went unnoticed because FML does not have package-level nullability annotations and the aforementioned method is no longer used once automatic rendering is shut down by the window takeover.
With my attempts at moving client mod loading out of the initial resource reload, this method continues rendering the ELS, except triggered from the main client thread instead of the separate "render executor" that is used until window takeover. The context being reset then causes the first attempt at interacting with GL (which unsurprisingly is a texture upload during the sync phase of the initial resource reload) to stall on a `while (GL11.glGetError() != 0) {}` loop intended to clear previous errors.