### PR TITLE
Fix texture uploads segfaulting in some cases

### DIFF
--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/error/FontLoader.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/error/FontLoader.java
@@ -21,15 +21,15 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-import net.neoforged.fml.earlydisplay.render.GlDebug;
-import net.neoforged.fml.earlydisplay.render.GlState;
 import net.neoforged.fml.earlydisplay.render.SimpleFont;
+import net.neoforged.fml.earlydisplay.render.Texture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11C;
 import org.lwjgl.opengl.GL12C;
+import org.lwjgl.opengl.GL30C;
 
 /**
  * Loader for the GNU Unifont font definitions included in vanilla MC
@@ -152,10 +152,6 @@ final class FontLoader {
 
     @Nullable
     private static SimpleFont buildFont(List<ProtoGlyph> glyphs) {
-        int textureId = GL11C.glGenTextures();
-        GlState.bindTexture2D(textureId);
-        GlDebug.labelTexture(textureId, "unifont texture");
-
         int totalPixels = glyphs.stream().mapToInt(g -> g.width * GLYPH_HEIGHT).sum();
         boolean incWidth = true;
         int texWidth = 512;
@@ -207,7 +203,12 @@ final class FontLoader {
             }
         }
 
-        GL11C.glTexImage2D(GL11C.GL_TEXTURE_2D, 0, GL11C.GL_RED, texWidth, texHeight, 0, GL11C.GL_RED, GL11C.GL_UNSIGNED_BYTE, bitmap);
+        int textureId = Texture.createEmpty("unifont texture", texWidth, texHeight, GL30C.GL_R8, GL11C.GL_RED, false);
+        GL11C.glPixelStorei(GL11C.GL_UNPACK_ROW_LENGTH, texWidth);
+        GL11C.glPixelStorei(GL11C.GL_UNPACK_SKIP_PIXELS, 0);
+        GL11C.glPixelStorei(GL11C.GL_UNPACK_SKIP_ROWS, 0);
+        GL11C.glPixelStorei(GL11C.GL_UNPACK_ALIGNMENT, 4);
+        GL11C.glTexSubImage2D(GL11C.GL_TEXTURE_2D, 0, 0, 0, texWidth, texHeight, GL11C.GL_RED, GL11C.GL_UNSIGNED_BYTE, bitmap);
         GL11C.glTexParameteri(GL11C.GL_TEXTURE_2D, GL11C.GL_TEXTURE_WRAP_S, GL12C.GL_CLAMP_TO_EDGE);
         GL11C.glTexParameteri(GL11C.GL_TEXTURE_2D, GL11C.GL_TEXTURE_WRAP_T, GL12C.GL_CLAMP_TO_EDGE);
         GL11C.glTexParameteri(GL11C.GL_TEXTURE_2D, GL11C.GL_TEXTURE_MAG_FILTER, GL11C.GL_NEAREST);

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/error/FontLoader.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/error/FontLoader.java
@@ -28,7 +28,6 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11C;
-import org.lwjgl.opengl.GL12C;
 import org.lwjgl.opengl.GL30C;
 
 /**
@@ -204,15 +203,7 @@ final class FontLoader {
         }
 
         int textureId = Texture.createEmpty("unifont texture", texWidth, texHeight, GL30C.GL_R8, GL11C.GL_RED, false);
-        GL11C.glPixelStorei(GL11C.GL_UNPACK_ROW_LENGTH, texWidth);
-        GL11C.glPixelStorei(GL11C.GL_UNPACK_SKIP_PIXELS, 0);
-        GL11C.glPixelStorei(GL11C.GL_UNPACK_SKIP_ROWS, 0);
-        GL11C.glPixelStorei(GL11C.GL_UNPACK_ALIGNMENT, 4);
-        GL11C.glTexSubImage2D(GL11C.GL_TEXTURE_2D, 0, 0, 0, texWidth, texHeight, GL11C.GL_RED, GL11C.GL_UNSIGNED_BYTE, bitmap);
-        GL11C.glTexParameteri(GL11C.GL_TEXTURE_2D, GL11C.GL_TEXTURE_WRAP_S, GL12C.GL_CLAMP_TO_EDGE);
-        GL11C.glTexParameteri(GL11C.GL_TEXTURE_2D, GL11C.GL_TEXTURE_WRAP_T, GL12C.GL_CLAMP_TO_EDGE);
-        GL11C.glTexParameteri(GL11C.GL_TEXTURE_2D, GL11C.GL_TEXTURE_MAG_FILTER, GL11C.GL_NEAREST);
-        GL11C.glTexParameteri(GL11C.GL_TEXTURE_2D, GL11C.GL_TEXTURE_MIN_FILTER, GL11C.GL_NEAREST);
+        Texture.writeToTexture(textureId, texWidth, texHeight, GL11C.GL_RED, 1, bitmap);
 
         // SimpleFont relies on at least a space character being present
         if (!glyphMap.containsKey((int) ' ')) {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/SimpleFont.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/SimpleFont.java
@@ -6,6 +6,13 @@
 package net.neoforged.fml.earlydisplay.render;
 
 import static org.lwjgl.opengl.GL11C.GL_NEAREST;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_ALIGNMENT;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_ROW_LENGTH;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_SKIP_PIXELS;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_SKIP_ROWS;
+import static org.lwjgl.opengl.GL11C.glPixelStorei;
+import static org.lwjgl.opengl.GL11C.glTexSubImage2D;
+import static org.lwjgl.opengl.GL30C.GL_R8;
 import static org.lwjgl.opengl.GL32C.GL_CLAMP_TO_EDGE;
 import static org.lwjgl.opengl.GL32C.GL_RED;
 import static org.lwjgl.opengl.GL32C.GL_TEXTURE_2D;
@@ -14,8 +21,6 @@ import static org.lwjgl.opengl.GL32C.GL_TEXTURE_MIN_FILTER;
 import static org.lwjgl.opengl.GL32C.GL_TEXTURE_WRAP_S;
 import static org.lwjgl.opengl.GL32C.GL_TEXTURE_WRAP_T;
 import static org.lwjgl.opengl.GL32C.GL_UNSIGNED_BYTE;
-import static org.lwjgl.opengl.GL32C.glGenTextures;
-import static org.lwjgl.opengl.GL32C.glTexImage2D;
 import static org.lwjgl.opengl.GL32C.glTexParameteri;
 import static org.lwjgl.stb.STBTruetype.stbtt_GetPackedQuad;
 import static org.lwjgl.stb.STBTruetype.stbtt_GetScaledFontVMetrics;
@@ -132,12 +137,10 @@ public class SimpleFont implements AutoCloseable {
             stbtt_GetScaledFontVMetrics(buf, 0, fontSize, ascent, descent, lineGap);
             this.lineSpacing = (int) (ascent[0] - descent[0] + lineGap[0]);
             this.descent = (int) Math.floor(descent[0]);
-            this.textureId = glGenTextures();
-            GlState.bindTexture2D(this.textureId);
-            GlDebug.labelTexture(this.textureId, "font texture " + resource);
+            int texwidth = 256;
+            int texheight = 128;
+            this.textureId = Texture.createEmpty("font texture " + resource, texwidth, texheight, GL_R8, GL_RED, false);
             try (var packedchars = STBTTPackedchar.malloc(ASCII_GLYPH_COUNT)) {
-                int texwidth = 256;
-                int texheight = 128;
                 try (STBTTPackRange.Buffer packRanges = STBTTPackRange.malloc(1)) {
                     var bitmap = BufferUtils.createByteBuffer(texwidth * texheight);
                     try (STBTTPackRange packRange = STBTTPackRange.malloc()) {
@@ -151,7 +154,11 @@ public class SimpleFont implements AutoCloseable {
                         stbtt_PackSetSkipMissingCodepoints(pc, true);
                         stbtt_PackFontRanges(pc, buf, 0, packRanges);
                         stbtt_PackEnd(pc);
-                        glTexImage2D(GL_TEXTURE_2D, 0, GL_RED, texwidth, texheight, 0, GL_RED, GL_UNSIGNED_BYTE, bitmap);
+                        glPixelStorei(GL_UNPACK_ROW_LENGTH, texwidth);
+                        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
+                        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
+                        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+                        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, texwidth, texheight, GL_RED, GL_UNSIGNED_BYTE, bitmap);
                         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
                         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
                         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/SimpleFont.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/SimpleFont.java
@@ -5,23 +5,8 @@
 
 package net.neoforged.fml.earlydisplay.render;
 
-import static org.lwjgl.opengl.GL11C.GL_NEAREST;
-import static org.lwjgl.opengl.GL11C.GL_UNPACK_ALIGNMENT;
-import static org.lwjgl.opengl.GL11C.GL_UNPACK_ROW_LENGTH;
-import static org.lwjgl.opengl.GL11C.GL_UNPACK_SKIP_PIXELS;
-import static org.lwjgl.opengl.GL11C.GL_UNPACK_SKIP_ROWS;
-import static org.lwjgl.opengl.GL11C.glPixelStorei;
-import static org.lwjgl.opengl.GL11C.glTexSubImage2D;
 import static org.lwjgl.opengl.GL30C.GL_R8;
-import static org.lwjgl.opengl.GL32C.GL_CLAMP_TO_EDGE;
 import static org.lwjgl.opengl.GL32C.GL_RED;
-import static org.lwjgl.opengl.GL32C.GL_TEXTURE_2D;
-import static org.lwjgl.opengl.GL32C.GL_TEXTURE_MAG_FILTER;
-import static org.lwjgl.opengl.GL32C.GL_TEXTURE_MIN_FILTER;
-import static org.lwjgl.opengl.GL32C.GL_TEXTURE_WRAP_S;
-import static org.lwjgl.opengl.GL32C.GL_TEXTURE_WRAP_T;
-import static org.lwjgl.opengl.GL32C.GL_UNSIGNED_BYTE;
-import static org.lwjgl.opengl.GL32C.glTexParameteri;
 import static org.lwjgl.stb.STBTruetype.stbtt_GetPackedQuad;
 import static org.lwjgl.stb.STBTruetype.stbtt_GetScaledFontVMetrics;
 import static org.lwjgl.stb.STBTruetype.stbtt_InitFont;
@@ -154,15 +139,7 @@ public class SimpleFont implements AutoCloseable {
                         stbtt_PackSetSkipMissingCodepoints(pc, true);
                         stbtt_PackFontRanges(pc, buf, 0, packRanges);
                         stbtt_PackEnd(pc);
-                        glPixelStorei(GL_UNPACK_ROW_LENGTH, texwidth);
-                        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
-                        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
-                        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-                        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, texwidth, texheight, GL_RED, GL_UNSIGNED_BYTE, bitmap);
-                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-                        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+                        Texture.writeToTexture(this.textureId, texwidth, texheight, GL_RED, 1, bitmap);
                     }
                 }
                 try (var q = STBTTAlignedQuad.malloc()) {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/Texture.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/Texture.java
@@ -99,7 +99,7 @@ public record Texture(int textureId, int physicalWidth, int physicalHeight,
         return texId;
     }
 
-    /// Write the provixed pixel buffer's contents to the specified texture.
+    /// Write the provided pixel buffer's contents to the specified texture.
     ///
     /// @param textureId      The GL ID of the target texture
     /// @param width          The width of the texture in pixels

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/Texture.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/Texture.java
@@ -55,20 +55,32 @@ public record Texture(int textureId, int physicalWidth, int physicalHeight,
         }
     }
 
+    /// Create a texture from the provided image.
+    ///
+    /// @param image     The image to write to the texture
+    /// @param debugName The name to use as GL debug label of the texture
+    /// @param scaling   The scaling to apply to the texture
+    /// @param animation The animation, if any, to render the texture with
     public static Texture create(
             UncompressedImage image,
             String debugName,
             TextureScaling scaling,
             @Nullable AnimationMetadata animation) {
+        // Initializing the texture (via glTexImage2D() with a null buffer) and writing its contents (via glTexSubImage2D())
+        // has to happen separately as doing both in one glTexImage2D() call may cause segfaults in some cases,
+        // particularly if invoked after vanilla has initialized its renderer and started creating its own textures.
         int texId = createEmpty(debugName, image.width(), image.height(), GL_RGBA8, GL_RGBA, scaling.linearScaling());
-        glPixelStorei(GL_UNPACK_ROW_LENGTH, image.width());
-        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
-        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
-        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, image.width(), image.height(), GL_RGBA, GL_UNSIGNED_BYTE, image.imageData());
+        writeToTexture(texId, image.width(), image.height(), GL_RGBA, 4, image.imageData());
         return new Texture(texId, image.width(), image.height(), scaling, animation);
     }
 
+    /// Create an empty GL texture with the specified parameters.
+    ///
+    /// @param width          The width of the texture in pixels
+    /// @param height         The height of the texture in pixels
+    /// @param internalFormat The internal GL format
+    /// @param externalFormat The external GL format
+    /// @param linearFilter   Whether the texture should use linear or nearest-neighbor filtering
     public static int createEmpty(
             String debugName,
             int width,
@@ -85,6 +97,29 @@ public record Texture(int textureId, int physicalWidth, int physicalHeight,
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, linearFilter ? GL_LINEAR : GL_NEAREST);
         glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, externalFormat, GL_UNSIGNED_BYTE, (ByteBuffer) null);
         return texId;
+    }
+
+    /// Write the provixed pixel buffer's contents to the specified texture.
+    ///
+    /// @param textureId      The GL ID of the target texture
+    /// @param width          The width of the texture in pixels
+    /// @param height         The height of the texture in pixels
+    /// @param externalFormat The external GL format
+    /// @param components     The amount of components per pixel
+    /// @param pixels         The pixel data to write to the texture
+    public static void writeToTexture(
+            int textureId,
+            int width,
+            int height,
+            int externalFormat,
+            int components,
+            ByteBuffer pixels) {
+        GlState.bindTexture2D(textureId);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, width);
+        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
+        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
+        glPixelStorei(GL_UNPACK_ALIGNMENT, components);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, externalFormat, GL_UNSIGNED_BYTE, pixels);
     }
 
     @Override

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/Texture.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/render/Texture.java
@@ -8,17 +8,25 @@ package net.neoforged.fml.earlydisplay.render;
 import static org.lwjgl.opengl.GL11C.GL_LINEAR;
 import static org.lwjgl.opengl.GL11C.GL_NEAREST;
 import static org.lwjgl.opengl.GL11C.GL_RGBA;
+import static org.lwjgl.opengl.GL11C.GL_RGBA8;
 import static org.lwjgl.opengl.GL11C.GL_TEXTURE_2D;
 import static org.lwjgl.opengl.GL11C.GL_TEXTURE_MAG_FILTER;
 import static org.lwjgl.opengl.GL11C.GL_TEXTURE_MIN_FILTER;
 import static org.lwjgl.opengl.GL11C.GL_TEXTURE_WRAP_S;
 import static org.lwjgl.opengl.GL11C.GL_TEXTURE_WRAP_T;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_ALIGNMENT;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_ROW_LENGTH;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_SKIP_PIXELS;
+import static org.lwjgl.opengl.GL11C.GL_UNPACK_SKIP_ROWS;
 import static org.lwjgl.opengl.GL11C.GL_UNSIGNED_BYTE;
 import static org.lwjgl.opengl.GL11C.glGenTextures;
+import static org.lwjgl.opengl.GL11C.glPixelStorei;
 import static org.lwjgl.opengl.GL11C.glTexImage2D;
 import static org.lwjgl.opengl.GL11C.glTexParameteri;
+import static org.lwjgl.opengl.GL11C.glTexSubImage2D;
 import static org.lwjgl.opengl.GL12C.GL_CLAMP_TO_EDGE;
 
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import net.neoforged.fml.earlydisplay.theme.AnimationMetadata;
 import net.neoforged.fml.earlydisplay.theme.TextureScaling;
@@ -52,16 +60,31 @@ public record Texture(int textureId, int physicalWidth, int physicalHeight,
             String debugName,
             TextureScaling scaling,
             @Nullable AnimationMetadata animation) {
-        var texId = glGenTextures();
+        int texId = createEmpty(debugName, image.width(), image.height(), GL_RGBA8, GL_RGBA, scaling.linearScaling());
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, image.width());
+        glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
+        glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
+        glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, image.width(), image.height(), GL_RGBA, GL_UNSIGNED_BYTE, image.imageData());
+        return new Texture(texId, image.width(), image.height(), scaling, animation);
+    }
+
+    public static int createEmpty(
+            String debugName,
+            int width,
+            int height,
+            int internalFormat,
+            int externalFormat,
+            boolean linearFilter) {
+        int texId = glGenTextures();
         GlState.bindTexture2D(texId);
         GlDebug.labelTexture(texId, debugName);
-        boolean linear = scaling.linearScaling();
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, linear ? GL_LINEAR : GL_NEAREST);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, linear ? GL_LINEAR : GL_NEAREST);
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, image.width(), image.height(), 0, GL_RGBA, GL_UNSIGNED_BYTE, image.imageData());
-        return new Texture(texId, image.width(), image.height(), scaling, animation);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, linearFilter ? GL_LINEAR : GL_NEAREST);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, linearFilter ? GL_LINEAR : GL_NEAREST);
+        glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, externalFormat, GL_UNSIGNED_BYTE, (ByteBuffer) null);
+        return texId;
     }
 
     @Override


### PR DESCRIPTION
This PR fixes texture uploads in the ELS and early error screen causing visual bugs or outright segfaulting in some cases, particularly when done after vanilla has initialized its renderer and started creating its own textures.

FML previously initialized textures and wrote their contents in a single `glTexImage2D()` call. Vanilla instead (partially by necessity since creating and writing are entirely separate code paths) uses `glTexImage2D()` with a null buffer to initialize textures and, at a later point, uses `glTexSubImage2D()` to write the texture's contents. This PR changes FML to do the same split init and write, fixing the visual bugs and segfault.