### PR TITLE
New: Enable Mixin Enum Extensions for targets which are not `IExtensibleEnum`s.

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinFeatureValidator.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinFeatureValidator.java
@@ -17,13 +17,12 @@ class FMLMixinFeatureValidator implements IFeatureValidator {
 
     @Override
     public void validateEnumExtension(IMixinInfo mixin, ClassInfo targetClass) throws InvalidMixinException {
-        String help = "";
         if (targetClass.findSuperClass(I_EXTENSIBLE_ENUM, ClassInfo.Traversal.ALL, true) != null) {
-            help = ". The target %s is an IExtensibleEnum which can be extended as described ".formatted(targetClass) +
-                    "here https://docs.neoforged.net/docs/advanced/extensibleenums/";
+            throw new InvalidMixinException(
+                    mixin,
+                    ("Mixin Enum Extensions are not supported on target %s because it is an IExtensibleEnum, which " +
+                            "should be extended as described here " +
+                            "https://docs.neoforged.net/docs/advanced/extensibleenums/").formatted(targetClass));
         }
-        throw new InvalidMixinException(
-                mixin,
-                "Mixin Enum Extensions are not currently supported on NeoForge" + help);
     }
 }


### PR DESCRIPTION
FAQs:
Q: Doesn't this make it breaking to make an enum newly extensible via IExtensibleEnum?
A: It already is since exhaustive switch statements will break

Q: Why should we allow mixin's enum extensions at all?
A: People are already using Mixin to extend enums. The new system is safer since it guarantees the same final order of enum constants for a given set of mixins. If it is disabled entirely, people will simply resort to the less safe way. Additionally, when people try to use the new system on IExtensibleEnums, they are stopped and directed to the docs for the proper way. No such error can exist for the old unsafe approach and continuing to encourage it would result in people mistakenly using it on IExtensibleEnums.