### PR TITLE
Improve error handling of mixins during mod construction

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLModContainer.java
+++ b/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLModContainer.java
@@ -24,12 +24,19 @@ import net.neoforged.fml.ModLoadingException;
 import net.neoforged.fml.ModLoadingIssue;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.fml.loading.FMLLoader;
+import net.neoforged.fml.loading.LoadingModList;
+import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.neoforgespi.language.IModInfo;
 import net.neoforged.neoforgespi.language.ModFileScanData;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
+import org.spongepowered.asm.mixin.FabricUtil;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+import org.spongepowered.asm.mixin.throwables.MixinApplyError;
+import org.spongepowered.asm.mixin.transformer.throwables.InvalidMixinException;
+import org.spongepowered.asm.mixin.transformer.throwables.MixinTransformerError;
 
 public class FMLModContainer extends ModContainer {
     private static final Logger LOGGER = LogManager.getLogger();
@@ -120,6 +127,7 @@ public class FMLModContainer extends ModContainer {
                 LOGGER.trace(LOADING, "Loaded mod instance {} of type {}", getModId(), modClass.getName());
             } catch (Throwable e) {
                 if (e instanceof InvocationTargetException) e = e.getCause(); // exceptions thrown when a reflected method call throws are wrapped in an InvocationTargetException. However, this isn't useful for the end user who has to dig through the logs to find the actual cause.
+                handleMixinError(e);
                 LOGGER.error(LOADING, "Failed to create mod instance. ModID: {}, class {}", getModId(), modClass.getName(), e);
                 throw new ModLoadingException(ModLoadingIssue.error("fml.modloadingissue.failedtoloadmod").withCause(e).withAffectedMod(modInfo));
             }
@@ -129,8 +137,27 @@ public class FMLModContainer extends ModContainer {
             AutomaticEventSubscriber.inject(this, this.scanResults, layer);
             LOGGER.trace(LOADING, "Completed Automatic event subscribers for {}", getModId());
         } catch (Throwable e) {
+            handleMixinError(e);
             LOGGER.error(LOADING, "Failed to register automatic subscribers. ModID: {}", getModId(), e);
             throw new ModLoadingException(ModLoadingIssue.error("fml.modloadingissue.failedtoloadmod").withCause(e).withAffectedMod(modInfo));
+        }
+    }
+    
+    // Gracefully handle any mixin errors that get thrown while loading mods and blame the correct mod for it
+    private void handleMixinError(Throwable e) {
+        if (e instanceof MixinTransformerError transformerError && 
+                transformerError.getCause() instanceof MixinApplyError mixinApplyError && 
+                mixinApplyError.getCause() instanceof InvalidMixinException invalidMixinException) {
+            IMixinInfo mixin = invalidMixinException.getMixin();
+            
+            String modId = FabricUtil.getModId(mixin.getConfig());
+            ModFileInfo modFileInfo = LoadingModList.get().getModFileById(modId);
+
+            LOGGER.error(LOADING, "Failed to apply mixin. Mixin Class: {}, ModID: {}", mixin.getClassName(), modId, invalidMixinException);
+            ModLoadingIssue issue = ModLoadingIssue.error("fml.modloadingissue.mixin.fail", mixin.getClassName(), modId)
+                    .withCause(invalidMixinException)
+                    .withAffectedModFile(modFileInfo.getFile());
+            throw new ModLoadingException(issue);
         }
     }
 

--- a/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLModContainer.java
+++ b/loader/src/main/java/net/neoforged/fml/javafmlmod/FMLModContainer.java
@@ -24,7 +24,6 @@ import net.neoforged.fml.ModLoadingException;
 import net.neoforged.fml.ModLoadingIssue;
 import net.neoforged.fml.event.IModBusEvent;
 import net.neoforged.fml.loading.FMLLoader;
-import net.neoforged.fml.loading.LoadingModList;
 import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.neoforgespi.language.IModInfo;
 import net.neoforged.neoforgespi.language.ModFileScanData;
@@ -142,16 +141,18 @@ public class FMLModContainer extends ModContainer {
             throw new ModLoadingException(ModLoadingIssue.error("fml.modloadingissue.failedtoloadmod").withCause(e).withAffectedMod(modInfo));
         }
     }
-    
+
     // Gracefully handle any mixin errors that get thrown while loading mods and blame the correct mod for it
     private void handleMixinError(Throwable e) {
-        if (e instanceof MixinTransformerError transformerError && 
-                transformerError.getCause() instanceof MixinApplyError mixinApplyError && 
+        if (e instanceof MixinTransformerError transformerError &&
+                transformerError.getCause() instanceof MixinApplyError mixinApplyError &&
                 mixinApplyError.getCause() instanceof InvalidMixinException invalidMixinException) {
             IMixinInfo mixin = invalidMixinException.getMixin();
-            
+
             String modId = FabricUtil.getModId(mixin.getConfig());
-            ModFileInfo modFileInfo = LoadingModList.get().getModFileById(modId);
+            ModFileInfo modFileInfo = FMLLoader.getCurrent()
+                    .getLoadingModList()
+                    .getModFileById(modId);
 
             LOGGER.error(LOADING, "Failed to apply mixin. Mixin Class: {}, ModID: {}", mixin.getClassName(), modId, invalidMixinException);
             ModLoadingIssue issue = ModLoadingIssue.error("fml.modloadingissue.mixin.fail", mixin.getClassName(), modId)

--- a/loader/src/main/resources/lang/en_us.json
+++ b/loader/src/main/resources/lang/en_us.json
@@ -89,5 +89,6 @@
   "fml.button.open.log": "Open Log File",
   "fml.button.open.crashreport": "Open Crash Report",
   "fml.button.open.mods.folder": "Open Mods Folder",
-  "fml.button.quit": "Quit Game"
+  "fml.button.quit": "Quit Game",
+  "fml.modloadingissue.mixin.fail": "Mixin application of {0} from {100,modinfo,name} ({100,modinfo,id}) has failed\n§7{102,exc,msg}"
 }


### PR DESCRIPTION
Simple change that just catches mixin transformer errors, unwraps them and blames the correct mod for them.

Previously if Mod A loaded class B, which Mod B had a mixin into which failed to apply, the error message would blame Mod A for that as it's the one that loaded Class B.