### PR TITLE
Ignore client enum extensions on dedicated server

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/common/asm/enumextension/RuntimeEnumExtender.java
+++ b/loader/src/main/java/net/neoforged/fml/common/asm/enumextension/RuntimeEnumExtender.java
@@ -16,10 +16,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.ModLoader;
 import net.neoforged.fml.ModLoadingIssue;
 import net.neoforged.fml.common.asm.ListGeneratorAdapter;
 import net.neoforged.fml.jarcontents.JarResource;
+import net.neoforged.fml.loading.FMLEnvironment;
 import net.neoforged.neoforgespi.language.IModInfo;
 import net.neoforged.neoforgespi.transformation.ClassProcessor;
 import net.neoforged.neoforgespi.transformation.ClassProcessorIds;
@@ -499,6 +501,9 @@ public class RuntimeEnumExtender implements ClassProcessor {
                 .stream()
                 .map(entry -> EnumPrototype.load(entry.getKey(), entry.getValue()))
                 .flatMap(List::stream)
+                .filter(proto ->
+                        FMLEnvironment.getDist() != Dist.DEDICATED_SERVER
+                                || !proto.enumName().startsWith("net/minecraft/client/"))
                 .sorted()
                 .reduce(
                         new HashMap<>(),

--- a/loader/src/main/java/net/neoforged/fml/common/asm/enumextension/RuntimeEnumExtender.java
+++ b/loader/src/main/java/net/neoforged/fml/common/asm/enumextension/RuntimeEnumExtender.java
@@ -501,9 +501,8 @@ public class RuntimeEnumExtender implements ClassProcessor {
                 .stream()
                 .map(entry -> EnumPrototype.load(entry.getKey(), entry.getValue()))
                 .flatMap(List::stream)
-                .filter(proto ->
-                        FMLEnvironment.getDist() != Dist.DEDICATED_SERVER
-                                || !proto.enumName().startsWith("net/minecraft/client/"))
+                .filter(proto -> FMLEnvironment.getDist() != Dist.DEDICATED_SERVER
+                        || !proto.enumName().startsWith("net/minecraft/client/"))
                 .sorted()
                 .reduce(
                         new HashMap<>(),


### PR DESCRIPTION
Ignore client-only enum extensions on dedicated servers.

Currently RuntimeEnumExtender attempts to load enum prototypes
for net/minecraft/client/* classes on dedicated servers.

This causes ClassNotFoundException for client-only extensible enums
such as net.minecraft.client.gui.Hud$HeartType.

The change filters client-side enum extensions when running on
Dist.DEDICATED_SERVER.