### PR TITLE
Expose issue tracker URL in IModFileInfo and relative tests

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFileInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModFileInfo.java
@@ -23,6 +23,7 @@ import net.neoforged.neoforgespi.language.IModInfo;
 import net.neoforged.neoforgespi.language.MavenVersionAdapter;
 import net.neoforged.neoforgespi.locating.InvalidModFileException;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 
 public class ModFileInfo implements IModFileInfo, IConfigurable {
@@ -139,7 +140,8 @@ public class ModFileInfo implements IModFileInfo, IConfigurable {
         return this;
     }
 
-    public URL getIssueURL() {
+    @Override
+    public @Nullable URL getIssueURL() {
         return issueURL;
     }
 

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/readers/JarModsDotTomlModFileReader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/readers/JarModsDotTomlModFileReader.java
@@ -6,7 +6,6 @@
 package net.neoforged.fml.loading.moddiscovery.readers;
 
 import com.mojang.logging.LogUtils;
-import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -133,11 +132,6 @@ public class JarModsDotTomlModFileReader implements IModFileReader {
         @Override
         public String getLicense() {
             return license;
-        }
-
-        @Override
-        public @Nullable URL getIssueURL() {
-            return null;
         }
 
         @Override

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/readers/JarModsDotTomlModFileReader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/readers/JarModsDotTomlModFileReader.java
@@ -6,6 +6,7 @@
 package net.neoforged.fml.loading.moddiscovery.readers;
 
 import com.mojang.logging.LogUtils;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -132,6 +133,11 @@ public class JarModsDotTomlModFileReader implements IModFileReader {
         @Override
         public String getLicense() {
             return license;
+        }
+
+        @Override
+        public @Nullable URL getIssueURL() {
+            return null;
         }
 
         @Override

--- a/loader/src/main/java/net/neoforged/neoforgespi/language/IModFileInfo.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/language/IModFileInfo.java
@@ -5,6 +5,7 @@
 
 package net.neoforged.neoforgespi.language;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import net.neoforged.neoforgespi.locating.IModFile;
@@ -33,4 +34,7 @@ public interface IModFileInfo {
     IModFile getFile();
 
     IConfigurable getConfig();
+
+    @Nullable
+    URL getIssueURL();
 }

--- a/loader/src/main/java/net/neoforged/neoforgespi/language/IModFileInfo.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/language/IModFileInfo.java
@@ -36,5 +36,7 @@ public interface IModFileInfo {
     IConfigurable getConfig();
 
     @Nullable
-    URL getIssueURL();
+    default URL getIssueURL() {
+        return null;
+    }
 }

--- a/loader/src/test/java/net/neoforged/fml/loading/moddiscovery/ModFileInfoTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/moddiscovery/ModFileInfoTest.java
@@ -75,4 +75,34 @@ class ModFileInfoTest {
         var mod = info.getMods().getFirst();
         assertEquals("testmod", mod.getModId());
     }
+
+    @Test
+    void testIssueTrackerURL() {
+        config.set("issueTrackerURL", "https://github.com/neoforged/NeoForge/issues");
+
+        IModFileInfo info = new ModFileInfo(modFile, new NightConfigWrapper(config), callback);
+
+        assertThat(info.getIssueURL()).hasToString("https://github.com/neoforged/NeoForge/issues");
+    }
+
+    @Test
+    void testMissingIssueTrackerURL() {
+        IModFileInfo info = new ModFileInfo(modFile, new NightConfigWrapper(config), callback);
+
+        assertThat(info.getIssueURL()).isNull();
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            ' '
+            https://example.invalid/issues
+            https://myurl.me/issues
+            """)
+    void testIgnoredIssueTrackerURL(String issueTrackerURL) {
+        config.set("issueTrackerURL", issueTrackerURL);
+
+        IModFileInfo info = new ModFileInfo(modFile, new NightConfigWrapper(config), callback);
+
+        assertThat(info.getIssueURL()).isNull();
+    }
 }


### PR DESCRIPTION
## Summary

Expose the file-level `issueTrackerURL` through `IModFileInfo`.

This adds `IModFileInfo#getIssueURL()` so SPI consumers can access the parsed issue tracker URL without depending on the `ModFileInfo` implementation class.

more information see relative issue neoforged/NeoForge#3138

## Tests

`./gradlew test `