### PR TITLE
Fix failure to recompute frames in mixins involving mixin-generated classes in stack frames

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/FMLLoader.java
@@ -442,6 +442,7 @@ public final class FMLLoader implements AutoCloseable {
         }
 
         builtInProcessors.add(mixinFacade.getClassProcessor());
+        builtInProcessors.add(mixinFacade.getGeneratingClassProcessor());
 
         return ClassProcessorSet.builder()
                 .markMarker(ClassProcessorIds.SIMPLE_PROCESSORS_GROUP)

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassBytecodeProvider.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLClassBytecodeProvider.java
@@ -13,16 +13,21 @@ import net.neoforged.neoforgespi.transformation.BytecodeProvider;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
 import org.spongepowered.asm.service.IClassBytecodeProvider;
+import org.spongepowered.asm.service.ISyntheticClassRegistry;
 import org.spongepowered.asm.transformers.MixinClassReader;
 
 class FMLClassBytecodeProvider implements IClassBytecodeProvider {
     private final BytecodeProvider bytecodeProvider;
-    private final FMLMixinClassProcessor classProcessor;
+    private final IMixinTransformer transformer;
+    private final ISyntheticClassRegistry registry;
 
-    FMLClassBytecodeProvider(BytecodeProvider bytecodeProvider, FMLMixinClassProcessor classProcessor) {
+    FMLClassBytecodeProvider(BytecodeProvider bytecodeProvider, FMLMixinService service) {
         this.bytecodeProvider = bytecodeProvider;
-        this.classProcessor = classProcessor;
+
+        this.transformer = service.getMixinTransformer();
+        this.registry = transformer.getExtensions().getSyntheticClassRegistry();
     }
 
     @Override
@@ -71,9 +76,9 @@ class FMLClassBytecodeProvider implements IClassBytecodeProvider {
         }
 
         Type classType = Type.getObjectType(internalName);
-        if (classProcessor.generatesClass(classType)) {
+        if (FMLMixinGeneratingClassProcessor.generatesClass(registry, classType)) {
             ClassNode classNode = new ClassNode();
-            if (classProcessor.generateClass(classType, classNode)) {
+            if (FMLMixinGeneratingClassProcessor.generateClass(transformer, classType, classNode)) {
                 return classNode;
             }
         }

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinClassProcessor.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinClassProcessor.java
@@ -10,7 +10,6 @@ import net.neoforged.neoforgespi.transformation.ClassProcessor;
 import net.neoforged.neoforgespi.transformation.ClassProcessorIds;
 import net.neoforged.neoforgespi.transformation.ProcessorName;
 import org.objectweb.asm.Type;
-import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.injection.invoke.arg.ArgsClassGenerator;
 import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
@@ -21,19 +20,12 @@ public class FMLMixinClassProcessor implements ClassProcessor {
     private final FMLClassTracker classTracker;
     private final IMixinTransformer transformer;
     private final ISyntheticClassRegistry registry;
-    private final FMLMixinService service;
 
     public FMLMixinClassProcessor(FMLMixinService service) {
         this.auditTrail = service.getInternalAuditTrail();
         this.classTracker = service.getInternalClassTracker();
         this.transformer = service.getMixinTransformer();
         this.registry = transformer.getExtensions().getSyntheticClassRegistry();
-        this.service = service;
-    }
-
-    @Override
-    public void link(LinkContext context) {
-        this.service.setBytecodeProvider(new FMLClassBytecodeProvider(context.bytecodeProvider(), this));
     }
 
     @Override
@@ -65,20 +57,12 @@ public class FMLMixinClassProcessor implements ClassProcessor {
             return false;
         }
 
-        return this.generatesClass(context.type());
+        return FMLMixinGeneratingClassProcessor.generatesClass(registry, context.type());
     }
 
     private boolean processesClass(Type classType) {
         MixinEnvironment environment = MixinEnvironment.getCurrentEnvironment();
         return this.transformer.couldTransformClass(environment, classType.getClassName());
-    }
-
-    boolean generatesClass(Type classType) {
-        return this.registry.findSyntheticClass(classType.getClassName()) != null;
-    }
-
-    boolean generateClass(Type classType, ClassNode classNode) {
-        return this.transformer.generateClass(MixinEnvironment.getCurrentEnvironment(), classType.getClassName(), classNode);
     }
 
     @Override
@@ -88,8 +72,8 @@ public class FMLMixinClassProcessor implements ClassProcessor {
 
         this.auditTrail.setConsumer(classType.getClassName(), context::audit);
 
-        if (this.generatesClass(classType)) {
-            return this.generateClass(classType, classNode) ? ComputeFlags.COMPUTE_FRAMES : ComputeFlags.NO_REWRITE;
+        if (FMLMixinGeneratingClassProcessor.generatesClass(registry, classType)) {
+            return FMLMixinGeneratingClassProcessor.generateClass(transformer, classType, classNode) ? ComputeFlags.COMPUTE_FRAMES : ComputeFlags.NO_REWRITE;
         }
 
         MixinEnvironment environment = MixinEnvironment.getCurrentEnvironment();

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
@@ -5,7 +5,6 @@
 
 package net.neoforged.fml.loading.mixin;
 
-import java.util.ArrayList;
 import java.util.Set;
 import net.neoforged.neoforgespi.transformation.ClassProcessor;
 import net.neoforged.neoforgespi.transformation.ClassProcessorIds;

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
@@ -85,22 +85,36 @@ public class FMLMixinGeneratingClassProcessor implements ClassProcessor {
         this.auditTrail.setConsumer(classType.getClassName(), context::audit);
 
         if (generatesClass(registry, classType)) {
+            var innerClasses = classNode.innerClasses;
+            var fields = classNode.fields;
+            var methods = classNode.methods;
+            var recordComponents = classNode.recordComponents;
+            var permittedSubclasses = classNode.permittedSubclasses;
+            var invisibleAnnotations = classNode.invisibleAnnotations;
+            var invisibleTypeAnnotations = classNode.invisibleTypeAnnotations;
+            var visibleAnnotations = classNode.visibleAnnotations;
+            var visibleTypeAnnotations = classNode.visibleTypeAnnotations;
+            var attrs = classNode.attrs;
+            var nestMembers = classNode.nestMembers;
+
             var generated = generateClass(transformer, classType, classNode);
             if (generated) {
                 // Clear out everything that the transformer will not expect to be there when it runs again
                 // This should, in theory, leave basically just the superclass declaration and the like
                 // Luckily, mixin class generators can be safely re-run (this is also done for the bytecode provider)
-                classNode.innerClasses = new ArrayList<>();
-                classNode.fields = new ArrayList<>();
-                classNode.methods = new ArrayList<>();
-                classNode.recordComponents = null;
-                classNode.permittedSubclasses = null;
-                classNode.invisibleAnnotations = null;
-                classNode.invisibleTypeAnnotations = null;
-                classNode.visibleAnnotations = null;
-                classNode.visibleTypeAnnotations = null;
-                classNode.attrs = null;
-                classNode.nestMembers = null;
+                //
+                // If the context is not empty, 
+                classNode.innerClasses = innerClasses;
+                classNode.fields = fields;
+                classNode.methods = methods;
+                classNode.recordComponents = recordComponents;
+                classNode.permittedSubclasses = permittedSubclasses;
+                classNode.invisibleAnnotations = invisibleAnnotations;
+                classNode.invisibleTypeAnnotations = invisibleTypeAnnotations;
+                classNode.visibleAnnotations = visibleAnnotations;
+                classNode.visibleTypeAnnotations = visibleTypeAnnotations;
+                classNode.attrs = attrs;
+                classNode.nestMembers = nestMembers;
 
                 return ComputeFlags.SIMPLE_REWRITE;
             }

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.fml.loading.mixin;
+
+import java.util.ArrayList;
+import java.util.Set;
+import net.neoforged.neoforgespi.transformation.ClassProcessor;
+import net.neoforged.neoforgespi.transformation.ClassProcessorIds;
+import net.neoforged.neoforgespi.transformation.ProcessorName;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.injection.invoke.arg.ArgsClassGenerator;
+import org.spongepowered.asm.mixin.transformer.IMixinTransformer;
+import org.spongepowered.asm.service.ISyntheticClassRegistry;
+
+/**
+ * Applies the parts of mixin transforms necessary for recomputing frames
+ */
+public class FMLMixinGeneratingClassProcessor implements ClassProcessor {
+    private final FMLAuditTrail auditTrail;
+    private final IMixinTransformer transformer;
+    private final ISyntheticClassRegistry registry;
+    private final FMLMixinService service;
+
+    public FMLMixinGeneratingClassProcessor(FMLMixinService service) {
+        this.service = service;
+        this.auditTrail = service.getInternalAuditTrail();
+        this.transformer = service.getMixinTransformer();
+        this.registry = transformer.getExtensions().getSyntheticClassRegistry();
+    }
+
+    @Override
+    public void link(LinkContext context) {
+        this.service.setBytecodeProvider(new FMLClassBytecodeProvider(context.bytecodeProvider(), this.service));
+    }
+
+    @Override
+    public ProcessorName name() {
+        return ClassProcessorIds.MIXIN_FRAME_CONTEXT;
+    }
+
+    @Override
+    public Set<ProcessorName> runsAfter() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<ProcessorName> runsBefore() {
+        return Set.of(ClassProcessorIds.COMPUTING_FRAMES, ClassProcessorIds.MIXIN);
+    }
+
+    @Override
+    public Set<String> generatesPackages() {
+        return Set.of(ArgsClassGenerator.SYNTHETIC_PACKAGE);
+    }
+
+    static boolean generatesClass(ISyntheticClassRegistry registry, Type classType) {
+        return registry.findSyntheticClass(classType.getClassName()) != null;
+    }
+
+    static boolean generateClass(IMixinTransformer transformer, Type classType, ClassNode classNode) {
+        return transformer.generateClass(MixinEnvironment.getCurrentEnvironment(), classType.getClassName(), classNode);
+    }
+
+    @Override
+    public boolean handlesClass(SelectionContext context) {
+        // This processor should process any class mixin generates
+        // It will run twice; mixin's processors seem to be fine with this
+        if (this.transformer.getExtensions().getSyntheticClassRegistry() == null) {
+            return false;
+        }
+
+        return generatesClass(registry, context.type());
+    }
+
+    @Override
+    public ComputeFlags processClass(TransformationContext context) {
+        var classType = context.type();
+        var classNode = context.node();
+
+        this.auditTrail.setConsumer(classType.getClassName(), context::audit);
+
+        if (generatesClass(registry, classType)) {
+            var generated = generateClass(transformer, classType, classNode);
+            if (generated) {
+                // Clear out everything that the transformer will not expect to be there when it runs again
+                // This should, in theory, leave basically just the superclass declaration and the like
+                // Luckily, mixin class generators can be safely re-run (this is also done for the bytecode provider)
+                classNode.innerClasses = new ArrayList<>();
+                classNode.fields = new ArrayList<>();
+                classNode.methods = new ArrayList<>();
+                classNode.recordComponents = null;
+                classNode.permittedSubclasses = null;
+                classNode.invisibleAnnotations = null;
+                classNode.invisibleTypeAnnotations = null;
+                classNode.visibleAnnotations = null;
+                classNode.visibleTypeAnnotations = null;
+                classNode.attrs = null;
+                classNode.nestMembers = null;
+
+                return ComputeFlags.SIMPLE_REWRITE;
+            }
+        }
+
+        return ComputeFlags.NO_REWRITE;
+    }
+}

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/FMLMixinGeneratingClassProcessor.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import net.neoforged.neoforgespi.transformation.ClassProcessor;
 import net.neoforged.neoforgespi.transformation.ClassProcessorIds;
 import net.neoforged.neoforgespi.transformation.ProcessorName;
+import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.MixinEnvironment;
@@ -85,36 +86,15 @@ public class FMLMixinGeneratingClassProcessor implements ClassProcessor {
         this.auditTrail.setConsumer(classType.getClassName(), context::audit);
 
         if (generatesClass(registry, classType)) {
-            var innerClasses = classNode.innerClasses;
-            var fields = classNode.fields;
-            var methods = classNode.methods;
-            var recordComponents = classNode.recordComponents;
-            var permittedSubclasses = classNode.permittedSubclasses;
-            var invisibleAnnotations = classNode.invisibleAnnotations;
-            var invisibleTypeAnnotations = classNode.invisibleTypeAnnotations;
-            var visibleAnnotations = classNode.visibleAnnotations;
-            var visibleTypeAnnotations = classNode.visibleTypeAnnotations;
-            var attrs = classNode.attrs;
-            var nestMembers = classNode.nestMembers;
+            var deepCopy = new ClassNode(Opcodes.ASM9);
+            classNode.accept(deepCopy);
 
-            var generated = generateClass(transformer, classType, classNode);
+            var generated = generateClass(transformer, classType, deepCopy);
             if (generated) {
-                // Clear out everything that the transformer will not expect to be there when it runs again
-                // This should, in theory, leave basically just the superclass declaration and the like
-                // Luckily, mixin class generators can be safely re-run (this is also done for the bytecode provider)
-                //
-                // If the context is not empty, 
-                classNode.innerClasses = innerClasses;
-                classNode.fields = fields;
-                classNode.methods = methods;
-                classNode.recordComponents = recordComponents;
-                classNode.permittedSubclasses = permittedSubclasses;
-                classNode.invisibleAnnotations = invisibleAnnotations;
-                classNode.invisibleTypeAnnotations = invisibleTypeAnnotations;
-                classNode.visibleAnnotations = visibleAnnotations;
-                classNode.visibleTypeAnnotations = visibleTypeAnnotations;
-                classNode.attrs = attrs;
-                classNode.nestMembers = nestMembers;
+                // Only copy over stuff needed for frames
+                // (type hierarchy)
+                classNode.superName = deepCopy.superName;
+                classNode.interfaces = deepCopy.interfaces;
 
                 return ComputeFlags.SIMPLE_REWRITE;
             }

--- a/loader/src/main/java/net/neoforged/fml/loading/mixin/MixinFacade.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/mixin/MixinFacade.java
@@ -39,6 +39,7 @@ public final class MixinFacade implements AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(MixinFacade.class);
 
     private final FMLMixinClassProcessor classProcessor;
+    private final FMLMixinGeneratingClassProcessor generatingClassProcessor;
     private final FMLMixinService service;
 
     public MixinFacade() {
@@ -53,10 +54,15 @@ public final class MixinFacade implements AutoCloseable {
 
         service = (FMLMixinService) MixinService.getService();
         this.classProcessor = new FMLMixinClassProcessor(service);
+        this.generatingClassProcessor = new FMLMixinGeneratingClassProcessor(service);
     }
 
     public FMLMixinClassProcessor getClassProcessor() {
         return classProcessor;
+    }
+
+    public FMLMixinGeneratingClassProcessor getGeneratingClassProcessor() {
+        return generatingClassProcessor;
     }
 
     public void finishInitialization(LoadingModList loadingModList, TransformingClassLoader classLoader) {

--- a/loader/src/main/java/net/neoforged/neoforgespi/transformation/ClassProcessorIds.java
+++ b/loader/src/main/java/net/neoforged/neoforgespi/transformation/ClassProcessorIds.java
@@ -23,6 +23,11 @@ public final class ClassProcessorIds {
     public static final ProcessorName RUNTIME_ENUM_EXTENDER = new ProcessorName("neoforge", "runtime_enum_extender");
     public static final ProcessorName ACCESS_TRANSFORMERS = new ProcessorName("neoforge", "access_transformer");
     public static final ProcessorName MIXIN = new ProcessorName("neoforge", "mixin");
+    /**
+     * A processor which makes superclass changes for mixins (such as for generated classes). Also serves as the capture
+     * point for mixin to look up bytecode.
+     */
+    public static final ProcessorName MIXIN_FRAME_CONTEXT = new ProcessorName("neoforge", "mixin_frame_context");
     public static final ProcessorName DIST_CLEANER = new ProcessorName("neoforge", "neoforge_dev_dist_cleaner");
 
     private ClassProcessorIds() {}

--- a/loader/src/test/java/net/neoforged/fml/loading/MixinConfigTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/MixinConfigTest.java
@@ -206,6 +206,62 @@ public class MixinConfigTest extends LauncherTest {
         assertThat(Mixins.getConfigs()).extracting("name").containsOnly("test.mixins.json");
     }
 
+    @Test
+    void testFrameRecomputationWithGeneratedClasses() throws Exception {
+        installation.setupProductionClient();
+        installation.buildModJar("mixin-test.jar")
+                .withTestmodModsToml(modsToml -> modsToml.addMixinConfig("test.mixins.json").addMod("test"))
+                .addTextFile("test.mixins.json", """
+                        {
+                            "package": "test.mixin",
+                            "mixins": ["RequiresFrameRecompute"]
+                        }
+                        """)
+                .addClass("test.target.Super", """
+                        public class Super {}
+                        """)
+                .addClass("test.target.Target", """
+                        import net.neoforged.fml.common.Mod;
+
+                        @Mod("test")
+                        public class Target {
+                            {
+                                test(null);
+                            }
+
+                            public static void test(Super obj) {}
+                        }
+                        """)
+                .addClass("test.mixin.RequiresFrameRecompute", """
+                        import org.spongepowered.asm.mixin.injection.At;
+                        import org.spongepowered.asm.mixin.injection.Inject;
+                        import org.spongepowered.asm.mixin.Mixin;
+                        import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+                        import test.target.Super;
+
+                        @Mixin(test.target.Target.class)
+                        public class RequiresFrameRecompute {
+                            @Inject(
+                                method = "test",
+                                at = @At("HEAD")
+                            )
+                            private static void testInject(Super obj, CallbackInfo ci) {
+                                // makes recomputing the stack necessary
+                                takesLocalType(alwaysFalse() ? obj : new Super() {});
+                            }
+
+                            private static boolean alwaysFalse() {
+                                return false;
+                            }
+
+                            private static void takesLocalType(Super object) {}
+                        }
+                        """)
+                .build();
+
+        var result = launchAndLoad("neoforgeclient");
+    }
+
     /**
      * Tests that Mixin configs declared only via the manifest are correctly picked up by Mixin.
      * <p>This is used by mixinextras, for example.

--- a/loader/src/test/java/net/neoforged/fml/loading/MixinConfigTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/MixinConfigTest.java
@@ -8,90 +8,16 @@ package net.neoforged.fml.loading;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import net.neoforged.fml.ModLoadingException;
-import net.neoforged.fml.loading.mixin.FMLMixinService;
 import net.neoforged.fml.loading.mixin.MixinFacade;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.spongepowered.asm.launch.MixinBootstrap;
-import org.spongepowered.asm.launch.platform.MixinPlatformManager;
-import org.spongepowered.asm.mixin.MixinEnvironment;
 import org.spongepowered.asm.mixin.Mixins;
-import org.spongepowered.asm.mixin.transformer.Config;
-import org.spongepowered.asm.service.MixinService;
-import org.spongepowered.asm.service.ServiceNotAvailableError;
 
-public class MixinConfigTest extends LauncherTest {
-    @BeforeEach
-    void cleanUpMixins() {
-        // What a mess. If we never successfully initialized Mixin
-        // we cannot even load the class, since it'd try to initialize a default service.
-        // See MixinFacade for details
-        if (System.getProperty("mixin.service") == null) {
-            return;
-        }
-
-        try {
-            Mixins.getConfigs().clear();
-        } catch (ServiceNotAvailableError ignored) {}
-
-        clearCollection(Config.class, null, "allConfigs");
-        clearCollection(Mixins.class, null, "registeredConfigs");
-
-        var service = (FMLMixinService) MixinService.getService();
-        service.clearMixinContainers();
-
-        // Clear root platform manager
-        var platform = MixinBootstrap.getPlatform();
-        clearCollection(MixinPlatformManager.class, platform, "containers");
-        setField(MixinPlatformManager.class, platform, "injected", false);
-        setField(MixinBootstrap.class, null, "platform", null); // Make MixinBootstrap call init on the platform again
-
-        gotoPhase(MixinEnvironment.Phase.PREINIT);
-    }
-
-    private void gotoPhase(MixinEnvironment.Phase phase) {
-        try {
-            var m = MixinEnvironment.class.getDeclaredMethod("gotoPhase", MixinEnvironment.Phase.class);
-            m.setAccessible(true);
-            m.invoke(null, phase);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static <T> void setField(Class<?> clazz, T instance, String fieldName, Object value) {
-        try {
-            var field = clazz.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            field.set(instance, value);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("Failed to set field value " + fieldName, e);
-        }
-    }
-
-    private static <T> void clearCollection(Class<T> clazz, T instance, String fieldName) {
-        Object obj;
-        try {
-            var field = clazz.getDeclaredField(fieldName);
-            field.setAccessible(true);
-            obj = field.get(instance);
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException("Failed to get field value " + fieldName, e);
-        }
-        switch (obj) {
-            case Map<?, ?> map -> map.clear();
-            case Collection<?> collection -> collection.clear();
-            case null -> {}
-            default -> throw new IllegalStateException("Don't know how to clear " + obj);
-        }
-    }
-
+public class MixinConfigTest extends LauncherTest implements MixinTestHelper {
     @Test
     void testRequiredModIsMissing() throws Exception {
         installation.setupProductionClient();
@@ -204,62 +130,6 @@ public class MixinConfigTest extends LauncherTest {
         launchAndLoad("neoforgeclient");
 
         assertThat(Mixins.getConfigs()).extracting("name").containsOnly("test.mixins.json");
-    }
-
-    @Test
-    void testFrameRecomputationWithGeneratedClasses() throws Exception {
-        installation.setupProductionClient();
-        installation.buildModJar("mixin-test.jar")
-                .withTestmodModsToml(modsToml -> modsToml.addMixinConfig("test.mixins.json").addMod("test"))
-                .addTextFile("test.mixins.json", """
-                        {
-                            "package": "test.mixin",
-                            "mixins": ["RequiresFrameRecompute"]
-                        }
-                        """)
-                .addClass("test.target.Super", """
-                        public class Super {}
-                        """)
-                .addClass("test.target.Target", """
-                        import net.neoforged.fml.common.Mod;
-
-                        @Mod("test")
-                        public class Target {
-                            {
-                                test(null);
-                            }
-
-                            public static void test(Super obj) {}
-                        }
-                        """)
-                .addClass("test.mixin.RequiresFrameRecompute", """
-                        import org.spongepowered.asm.mixin.injection.At;
-                        import org.spongepowered.asm.mixin.injection.Inject;
-                        import org.spongepowered.asm.mixin.Mixin;
-                        import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-                        import test.target.Super;
-
-                        @Mixin(test.target.Target.class)
-                        public class RequiresFrameRecompute {
-                            @Inject(
-                                method = "test",
-                                at = @At("HEAD")
-                            )
-                            private static void testInject(Super obj, CallbackInfo ci) {
-                                // makes recomputing the stack necessary
-                                takesLocalType(alwaysFalse() ? obj : new Super() {});
-                            }
-
-                            private static boolean alwaysFalse() {
-                                return false;
-                            }
-
-                            private static void takesLocalType(Super object) {}
-                        }
-                        """)
-                .build();
-
-        var result = launchAndLoad("neoforgeclient");
     }
 
     /**

--- a/loader/src/test/java/net/neoforged/fml/loading/MixinTestHelper.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/MixinTestHelper.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.fml.loading;
+
+import java.util.Collection;
+import java.util.Map;
+import net.neoforged.fml.loading.mixin.FMLMixinService;
+import org.junit.jupiter.api.BeforeEach;
+import org.spongepowered.asm.launch.MixinBootstrap;
+import org.spongepowered.asm.launch.platform.MixinPlatformManager;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.Mixins;
+import org.spongepowered.asm.mixin.transformer.Config;
+import org.spongepowered.asm.service.MixinService;
+import org.spongepowered.asm.service.ServiceNotAvailableError;
+
+public interface MixinTestHelper {
+    @BeforeEach
+    default void cleanUpMixins() {
+        // What a mess. If we never successfully initialized Mixin
+        // we cannot even load the class, since it'd try to initialize a default service.
+        // See MixinFacade for details
+        if (System.getProperty("mixin.service") == null) {
+            return;
+        }
+
+        try {
+            Mixins.getConfigs().clear();
+        } catch (ServiceNotAvailableError ignored) {}
+
+        clearCollection(Config.class, null, "allConfigs");
+        clearCollection(Mixins.class, null, "registeredConfigs");
+
+        var service = (FMLMixinService) MixinService.getService();
+        service.clearMixinContainers();
+
+        // Clear root platform manager
+        var platform = MixinBootstrap.getPlatform();
+        clearCollection(MixinPlatformManager.class, platform, "containers");
+        setField(MixinPlatformManager.class, platform, "injected", false);
+        setField(MixinBootstrap.class, null, "platform", null); // Make MixinBootstrap call init on the platform again
+
+        gotoPhase(MixinEnvironment.Phase.PREINIT);
+    }
+
+    private void gotoPhase(MixinEnvironment.Phase phase) {
+        try {
+            var m = MixinEnvironment.class.getDeclaredMethod("gotoPhase", MixinEnvironment.Phase.class);
+            m.setAccessible(true);
+            m.invoke(null, phase);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static <T> void setField(Class<?> clazz, T instance, String fieldName, Object value) {
+        try {
+            var field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(instance, value);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to set field value " + fieldName, e);
+        }
+    }
+
+    private static <T> void clearCollection(Class<T> clazz, T instance, String fieldName) {
+        Object obj;
+        try {
+            var field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            obj = field.get(instance);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException("Failed to get field value " + fieldName, e);
+        }
+        switch (obj) {
+            case Map<?, ?> map -> map.clear();
+            case Collection<?> collection -> collection.clear();
+            case null -> {}
+            default -> throw new IllegalStateException("Don't know how to clear " + obj);
+        }
+    }
+}

--- a/loader/src/test/java/net/neoforged/fml/loading/MixinTransformationTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/MixinTransformationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.fml.loading;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class MixinTransformationTest extends LauncherTest implements MixinTestHelper {
+    @Test
+    void testFrameRecomputationWithGeneratedClasses() throws Exception {
+        installation.setupProductionClient();
+        installation.buildModJar("mixin-test.jar")
+                .withTestmodModsToml(modsToml -> modsToml.addMixinConfig("test.mixins.json").addMod("test"))
+                .addTextFile("test.mixins.json", """
+                        {
+                            "package": "test.mixin",
+                            "mixins": ["RequiresFrameRecompute"]
+                        }
+                        """)
+                .addClass("test.target.Super", """
+                        public class Super {}
+                        """)
+                .addClass("test.target.IFace", """
+                        public interface IFace {}
+                        """)
+                .addClass("test.target.Target", """
+                        import net.neoforged.fml.common.Mod;
+
+                        @Mod("test")
+                        public class Target {
+                            {
+                                test(null);
+                            }
+
+                            public static void test(Super obj) {}
+                        }
+                        """)
+                .addClass("test.mixin.RequiresFrameRecompute", """
+                        import org.spongepowered.asm.mixin.injection.At;
+                        import org.spongepowered.asm.mixin.injection.Inject;
+                        import org.spongepowered.asm.mixin.Mixin;
+                        import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+                        import test.target.Super;
+
+                        @Mixin(test.target.Target.class)
+                        public class RequiresFrameRecompute implements test.target.IFace {
+                            @Inject(
+                                method = "test",
+                                at = @At("HEAD")
+                            )
+                            private static void testInject(Super obj, CallbackInfo ci) {
+                                // makes recomputing the stack necessary
+                                takesLocalType(alwaysFalse() ? obj : new Super() {});
+                            }
+
+                            private static boolean alwaysFalse() {
+                                return false;
+                            }
+
+                            private static void takesLocalType(Super object) {}
+                        }
+                        """)
+                .build();
+
+        var result = launchAndLoad("neoforgeclient");
+        var testClass = result.launchClassLoader().loadClass("test.target.Target");
+        var injectedInterface = result.launchClassLoader().loadClass("test.target.IFace");
+        assertTrue(injectedInterface.isAssignableFrom(testClass));
+    }
+}


### PR DESCRIPTION
Fixes #434

In certain scenarios frame recomputation of Mixin classes needs to see the superclass of a class mixin generates. However, mixin-generated classes (as well as normal mixin classes) themselves may need frame computation, so that transform cannot be placed before `neoforge:computing_frames`! (Basically, a given class processor can _either_ have the ability to have its changes be counted for frame computing, or can request computing itself. This is to avoid circularity).

I fix this through a few changes:
- Make a new class processor, `neoforge:mixin_frame_context`, responsible for making any mixin changes that will affect frame computation
- Move the bytecode capture point used by mixin to look up class hierarchy to this point (this is necessary to avoid circularity)
- `neoforge:mixin_frame_context` runs `generateClass` on classes-to-be-generated on a copy of the received class node, then copies over any changes in super type to the actual classnode.This occurs _before_ `neoforge:computing_frames`
- `neoforge:mixin` runs `generateClass` to properly generate the class normally, later, as before.

Basically: I apply the changes in super type earlier by re-running the generator. Generators are safe to re-run -- FML already did that in `FMLClassBytecodeProvider`. The capture point has to be moved earlier because generators could request stuff from the mixin service, including looking up class info; I suspect this will not have any interesting effects in practice.