### PR TITLE
Rename config types

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
@@ -209,10 +209,10 @@ public class ConfigTracker {
         modConfig.setConfig(new LoadedConfig(newConfig, null, modConfig), ModConfigEvent.Reloading::new); // TODO: should maybe be Loading on the first load?
     }
 
-    public void loadDefaultSharedConfigs() {
-        configSets.get(ModConfig.Type.SHARED).forEach(modConfig -> {
+    public void loadDefaultSyncedConfigs() {
+        configSets.get(ModConfig.Type.SYNCED).forEach(modConfig -> {
             if (modConfig.loadedConfig != null) {
-                LOGGER.warn("Overwriting non-null config {} at path {} with default shared config", modConfig.loadedConfig, modConfig.getFileName());
+                LOGGER.warn("Overwriting non-null config {} at path {} with default synced config", modConfig.loadedConfig, modConfig.getFileName());
             }
 
             modConfig.setConfig(new LoadedConfig(createDefaultConfig(modConfig.getSpec()), null, modConfig), ModConfigEvent.Loading::new);

--- a/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ConfigTracker.java
@@ -209,10 +209,10 @@ public class ConfigTracker {
         modConfig.setConfig(new LoadedConfig(newConfig, null, modConfig), ModConfigEvent.Reloading::new); // TODO: should maybe be Loading on the first load?
     }
 
-    public void loadDefaultServerConfigs() {
-        configSets.get(ModConfig.Type.SERVER).forEach(modConfig -> {
+    public void loadDefaultSharedConfigs() {
+        configSets.get(ModConfig.Type.SHARED).forEach(modConfig -> {
             if (modConfig.loadedConfig != null) {
-                LOGGER.warn("Overwriting non-null config {} at path {} with default server config", modConfig.loadedConfig, modConfig.getFileName());
+                LOGGER.warn("Overwriting non-null config {} at path {} with default shared config", modConfig.loadedConfig, modConfig.getFileName());
             }
 
             modConfig.setConfig(new LoadedConfig(createDefaultConfig(modConfig.getSpec()), null, modConfig), ModConfigEvent.Loading::new);

--- a/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
@@ -86,13 +86,13 @@ public final class ModConfig {
 
     public enum Type {
         /**
-         * Common mod config for configuration that needs to be loaded on both environments.
+         * Standard mod config for configuration that needs to be loaded on both environments.
          * Loaded on both servers and clients.
          * Stored in the global config directory.
          * Not synced.
-         * Suffix is "-common" by default.
+         * Suffix is "-standard" by default.
          */
-        COMMON,
+        STANDARD,
         /**
          * Client config is for configuration affecting the ONLY client state such as graphical options.
          * Only loaded on the client side.
@@ -102,13 +102,13 @@ public final class ModConfig {
          */
         CLIENT,
         /**
-         * Server type config is configuration that is associated with a server instance.
+         * Shared config is configuration that is associated with a server instance and synced to connected clients.
          * Only loaded during server startup.
-         * Stored in a server/save specific "serverconfig" directory.
+         * Stored in a server/save specific "sharedconfig" directory.
          * Synced to clients during connection.
-         * Suffix is "-server" by default.
+         * Suffix is "-shared" by default.
          */
-        SERVER,
+        SHARED,
         /**
          * Startup configs are for configurations that need to run as early as possible.
          * Loaded as soon as the config is registered to FML.

--- a/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
+++ b/loader/src/main/java/net/neoforged/fml/config/ModConfig.java
@@ -86,13 +86,13 @@ public final class ModConfig {
 
     public enum Type {
         /**
-         * Standard mod config for configuration that needs to be loaded on both environments.
+         * Local mod config for configuration that needs to be loaded on both environments.
          * Loaded on both servers and clients.
          * Stored in the global config directory.
          * Not synced.
-         * Suffix is "-standard" by default.
+         * Suffix is "-local" by default.
          */
-        STANDARD,
+        LOCAL,
         /**
          * Client config is for configuration affecting the ONLY client state such as graphical options.
          * Only loaded on the client side.
@@ -102,13 +102,13 @@ public final class ModConfig {
          */
         CLIENT,
         /**
-         * Shared config is configuration that is associated with a server instance and synced to connected clients.
+         * Synced config is configuration that is associated with a server instance and synced to connected clients.
          * Only loaded during server startup.
-         * Stored in a server/save specific "sharedconfig" directory.
+         * Stored in a server/save specific "syncedconfig" directory.
          * Synced to clients during connection.
-         * Suffix is "-shared" by default.
+         * Suffix is "-synced" by default.
          */
-        SHARED,
+        SYNCED,
         /**
          * Startup configs are for configurations that need to run as early as possible.
          * Loaded as soon as the config is registered to FML.

--- a/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
+++ b/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
@@ -180,7 +180,7 @@ public class ConfigTrackerTest {
             }
         };
         Assertions.assertThatIllegalArgumentException()
-                .isThrownBy(() -> configTracker.registerConfig(ModConfig.Type.COMMON, spec, modContainer, "test.toml"));
+                .isThrownBy(() -> configTracker.registerConfig(ModConfig.Type.STANDARD, spec, modContainer, "test.toml"));
     }
 
     private void waitUntil(Runnable assertion) throws InterruptedException {

--- a/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
+++ b/loader/src/test/java/net/neoforged/fml/config/ConfigTrackerTest.java
@@ -180,7 +180,7 @@ public class ConfigTrackerTest {
             }
         };
         Assertions.assertThatIllegalArgumentException()
-                .isThrownBy(() -> configTracker.registerConfig(ModConfig.Type.STANDARD, spec, modContainer, "test.toml"));
+                .isThrownBy(() -> configTracker.registerConfig(ModConfig.Type.LOCAL, spec, modContainer, "test.toml"));
     }
 
     private void waitUntil(Runnable assertion) throws InterruptedException {


### PR DESCRIPTION
SERVER -> SYNCED
COMMON -> LOCAL

The idea here is making it clear that the was SERVER configs are synced between client and server (with the comment on it explaining the sync direction). And changing COMMON to LOCAL makes it clears COMMON is not a synced config. Rather just a regular default standard config with no sync involved. 

Changes were limited to renames to keep PR as small as possible. Any alternative names will need a very strong reason to convince me to change it.

If you wish for a different setup such as sync-ness as part of the config setup or removal of an entire config type, please make a separate PR and post it in comment here so implementations can be judged. Also helps to reduce bikeshedding by pushing forth a "less-talking, more-doing" stance to this.

Ideally we would target 26.3 for this. Once merged, NeoForge will get a PR to use new FML and make the same config name changes (including to the config files and folders to match new name).

This is a large scale breaking change and will need a dev announcement when NeoForge updates.

Closes: https://github.com/neoforged/FancyModLoader/issues/276

EDIT: names changes based on maintainer feedback