### PR TITLE
Set the macOS application icon

### DIFF
--- a/earlydisplay/build.gradle
+++ b/earlydisplay/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation("org.lwjgl:lwjgl-tinyfd")
     implementation("org.slf4j:slf4j-api:${slf4j_api_version}")
     implementation("net.sf.jopt-simple:jopt-simple:${jopt_simple_version}")
+
     testImplementation(platform("org.junit:junit-bom:$jupiter_version"))
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/earlydisplay/build.gradle
+++ b/earlydisplay/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation("org.lwjgl:lwjgl-tinyfd")
     implementation("org.slf4j:slf4j-api:${slf4j_api_version}")
     implementation("net.sf.jopt-simple:jopt-simple:${jopt_simple_version}")
+    compileOnly("ca.weblite:java-objc-bridge:1.1")
 
     testImplementation(platform("org.junit:junit-bom:$jupiter_version"))
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')

--- a/earlydisplay/build.gradle
+++ b/earlydisplay/build.gradle
@@ -25,8 +25,6 @@ dependencies {
     implementation("org.lwjgl:lwjgl-tinyfd")
     implementation("org.slf4j:slf4j-api:${slf4j_api_version}")
     implementation("net.sf.jopt-simple:jopt-simple:${jopt_simple_version}")
-    compileOnly("ca.weblite:java-objc-bridge:1.1")
-
     testImplementation(platform("org.junit:junit-bom:$jupiter_version"))
     testRuntimeOnly('org.junit.platform:junit-platform-launcher')
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -438,9 +438,9 @@ public class DisplayWindow implements ImmediateWindowProvider {
 
     private void setGlfwWindowIcon() {
         try (var glfwImgBuffer = GLFWImage.malloc(1);
-                var glfwImage = GLFWImage.malloc();
+                var glfwImages = GLFWImage.malloc();
                 var icon = theme.windowIcon().loadAsImage(getThemePath())) {
-            glfwImgBuffer.put(glfwImage.set(icon.width(), icon.height(), icon.imageData()));
+            glfwImgBuffer.put(glfwImages.set(icon.width(), icon.height(), icon.imageData()));
             glfwImgBuffer.flip();
             glfwSetWindowIcon(window, glfwImgBuffer);
         } catch (Exception e) {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/DisplayWindow.java
@@ -18,6 +18,7 @@ import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_DEBUG_CONTEXT;
 import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_FORWARD_COMPAT;
 import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_PROFILE;
 import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM;
+import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_COCOA;
 import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_WAYLAND;
 import static org.lwjgl.glfw.GLFW.GLFW_PLATFORM_X11;
 import static org.lwjgl.glfw.GLFW.GLFW_RESIZABLE;
@@ -30,6 +31,7 @@ import static org.lwjgl.glfw.GLFW.glfwCreateWindow;
 import static org.lwjgl.glfw.GLFW.glfwDefaultWindowHints;
 import static org.lwjgl.glfw.GLFW.glfwGetError;
 import static org.lwjgl.glfw.GLFW.glfwGetMonitorPos;
+import static org.lwjgl.glfw.GLFW.glfwGetPlatform;
 import static org.lwjgl.glfw.GLFW.glfwGetPrimaryMonitor;
 import static org.lwjgl.glfw.GLFW.glfwGetVideoMode;
 import static org.lwjgl.glfw.GLFW.glfwGetWindowSize;
@@ -415,17 +417,7 @@ public class DisplayWindow implements ImmediateWindowProvider {
 
         glfwSetWindowPos(window, (vidmode.width() - this.winWidth) / 2 + monitorX, (vidmode.height() - this.winHeight) / 2 + monitorY);
 
-        // Attempt setting the icon
-        try (var glfwImgBuffer = GLFWImage.malloc(1);
-                var glfwImages = GLFWImage.malloc();
-                var icon = theme.windowIcon().loadAsImage(getThemePath())) {
-            glfwImgBuffer.put(glfwImages.set(icon.width(), icon.height(), icon.imageData()));
-            glfwImgBuffer.flip();
-            glfwSetWindowIcon(window, glfwImgBuffer);
-        } catch (Exception e) {
-            LOGGER.error("Failed to load NeoForged icon", e);
-        }
-        getLastGlfwError().ifPresent(error -> LOGGER.warn("Failed to set window icon: {}", error));
+        setWindowIcon();
 
         glfwSetWindowSizeCallback(window, this::winResize);
 
@@ -433,6 +425,36 @@ public class DisplayWindow implements ImmediateWindowProvider {
         glfwShowWindow(window);
         getLastGlfwError().ifPresent(error -> LOGGER.warn("Failed to show and position window: {}", error));
         glfwPollEvents();
+    }
+
+    private void setWindowIcon() {
+        if (glfwGetPlatform() == GLFW_PLATFORM_COCOA) {
+            setMacosApplicationIcon();
+            return;
+        }
+
+        setGlfwWindowIcon();
+    }
+
+    private void setGlfwWindowIcon() {
+        try (var glfwImgBuffer = GLFWImage.malloc(1);
+                var glfwImage = GLFWImage.malloc();
+                var icon = theme.windowIcon().loadAsImage(getThemePath())) {
+            glfwImgBuffer.put(glfwImage.set(icon.width(), icon.height(), icon.imageData()));
+            glfwImgBuffer.flip();
+            glfwSetWindowIcon(window, glfwImgBuffer);
+        } catch (Exception e) {
+            LOGGER.error("Failed to load NeoForged icon", e);
+        }
+        getLastGlfwError().ifPresent(error -> LOGGER.warn("Failed to set window icon: {}", error));
+    }
+
+    private void setMacosApplicationIcon() {
+        try (var icon = theme.windowIcon().toNativeBuffer(getThemePath())) {
+            MacosApplicationIcon.set(icon.toByteArray());
+        } catch (Exception | LinkageError e) {
+            LOGGER.warn("Failed to set macOS application icon", e);
+        }
     }
 
     private void winResize(long window, int width, int height) {

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/MacosApplicationIcon.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/MacosApplicationIcon.java
@@ -5,17 +5,56 @@
 
 package net.neoforged.fml.earlydisplay;
 
-import ca.weblite.objc.Client;
-import java.util.Base64;
+import java.nio.ByteBuffer;
+import org.lwjgl.system.JNI;
+import org.lwjgl.system.MemoryUtil;
+import org.lwjgl.system.macosx.ObjCRuntime;
 
+/**
+ * Sets the macOS application icon by sending messages directly to AppKit through the Objective-C runtime.
+ *
+ * <p>The native function, class, and selector handles are pointers, which LWJGL represents as {@code long} values.
+ */
 final class MacosApplicationIcon {
+    // Objective-C method calls are dispatched through objc_msgSend(receiver, selector, arguments...)
+    private static final long OBJC_MSG_SEND = ObjCRuntime.getLibrary().getFunctionAddress("objc_msgSend");
+
+    // handles for the AppKit/Foundation classes used below
+    private static final long NS_DATA = ObjCRuntime.objc_getClass("NSData");
+    private static final long NS_IMAGE = ObjCRuntime.objc_getClass("NSImage");
+    private static final long NS_APPLICATION = ObjCRuntime.objc_getClass("NSApplication");
+
+    // selectors identify the Objective-C methods passed to objc_msgSend
+    private static final long DATA_WITH_BYTES = ObjCRuntime.sel_registerName("dataWithBytes:length:");
+    private static final long ALLOC = ObjCRuntime.sel_registerName("alloc");
+    private static final long INIT_WITH_DATA = ObjCRuntime.sel_registerName("initWithData:");
+    private static final long SHARED_APPLICATION = ObjCRuntime.sel_registerName("sharedApplication");
+    private static final long SET_APPLICATION_ICON_IMAGE = ObjCRuntime.sel_registerName("setApplicationIconImage:");
+
     private MacosApplicationIcon() {}
 
     static void set(byte[] iconData) {
-        String encodedIcon = Base64.getEncoder().encodeToString(iconData);
-        Client objc = Client.getInstance();
-        Object data = objc.sendProxy("NSData", "alloc").send("initWithBase64Encoding:", encodedIcon);
-        Object image = objc.sendProxy("NSImage", "alloc").send("initWithData:", data);
-        objc.sendProxy("NSApplication", "sharedApplication").send("setApplicationIconImage:", image);
+        // Copy the Java array into native memory so Objective-C can receive a stable pointer to its bytes
+        ByteBuffer iconBuffer = MemoryUtil.memAlloc(iconData.length);
+        try {
+            // flip() resets the position after the write so memAddress() points to the first icon byte
+            iconBuffer.put(iconData).flip();
+
+            // Equivalent to: [NSData dataWithBytes:iconBuffer length:iconData.length]
+            // NSData copies the bytes, so the native buffer only needs to live until this call returns
+            long data = JNI.invokePPPPP(NS_DATA, DATA_WITH_BYTES, MemoryUtil.memAddress(iconBuffer), iconData.length, OBJC_MSG_SEND);
+
+            // Equivalent to: [[NSImage alloc] initWithData:data]
+            long image = JNI.invokePPPP(JNI.invokePPP(NS_IMAGE, ALLOC, OBJC_MSG_SEND), INIT_WITH_DATA, data, OBJC_MSG_SEND);
+
+            // Equivalent to: [NSApplication sharedApplication]
+            long application = JNI.invokePPP(NS_APPLICATION, SHARED_APPLICATION, OBJC_MSG_SEND);
+
+            // Equivalent to: [application setApplicationIconImage:image]
+            JNI.invokePPPV(application, SET_APPLICATION_ICON_IMAGE, image, OBJC_MSG_SEND);
+        } finally {
+            // Memory allocated by MemoryUtil is not managed by the Java garbage collector so we have to free it
+            MemoryUtil.memFree(iconBuffer);
+        }
     }
 }

--- a/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/MacosApplicationIcon.java
+++ b/earlydisplay/src/main/java/net/neoforged/fml/earlydisplay/MacosApplicationIcon.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.fml.earlydisplay;
+
+import ca.weblite.objc.Client;
+import java.util.Base64;
+
+final class MacosApplicationIcon {
+    private MacosApplicationIcon() {}
+
+    static void set(byte[] iconData) {
+        String encodedIcon = Base64.getEncoder().encodeToString(iconData);
+        Client objc = Client.getInstance();
+        Object data = objc.sendProxy("NSData", "alloc").send("initWithBase64Encoding:", encodedIcon);
+        Object image = objc.sendProxy("NSImage", "alloc").send("initWithData:", data);
+        objc.sendProxy("NSApplication", "sharedApplication").send("setApplicationIconImage:", image);
+    }
+}


### PR DESCRIPTION
GLFW cannot set regular window icons on macOS, so the early-loading process was appearing with a generic Java or terminal icon in the Dock. Now it'll show the neoforge icon like the other platforms.