### PR TITLE
[1.21.1 backport] Fix dependency cycle reporting (#427)

### DIFF
--- a/loader/src/main/java/net/neoforged/fml/loading/ModSorter.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/ModSorter.java
@@ -32,7 +32,6 @@ import java.util.stream.Stream;
 import net.neoforged.fml.ModLoadingException;
 import net.neoforged.fml.ModLoadingIssue;
 import net.neoforged.fml.loading.moddiscovery.ModFile;
-import net.neoforged.fml.loading.moddiscovery.ModFileInfo;
 import net.neoforged.fml.loading.moddiscovery.ModInfo;
 import net.neoforged.fml.loading.toposort.CyclePresentException;
 import net.neoforged.fml.loading.toposort.TopologicalSort;
@@ -82,7 +81,7 @@ public class ModSorter {
             if (modLoadingException == null) {
                 list = LoadingModList.of(plugins, ms.modFiles, ms.sortedList, issues, ms.modDependencies);
             } else {
-                list = LoadingModList.of(plugins, ms.modFiles, ms.sortedList, concat(issues, modLoadingException.getIssues()), Map.of());
+                list = LoadingModList.of(plugins, ms.systemMods, ms.systemMods.stream().map(mf -> (ModInfo) mf.getModInfos().get(0)).collect(toList()), concat(issues, modLoadingException.getIssues()), Map.of());
             }
         }
 
@@ -144,14 +143,15 @@ public class ModSorter {
         try {
             sorted = TopologicalSort.topologicalSort(graph, Comparator.comparing(infos::get));
         } catch (CyclePresentException e) {
-            Set<Set<ModFileInfo>> cycles = e.getCycles();
+            Set<Set<ModInfo>> cycles = e.getCycles();
             if (LOGGER.isErrorEnabled(LogMarkers.LOADING)) {
                 LOGGER.error(LogMarkers.LOADING, "Mod Sorting failed.\nDetected Cycles: {}\n", cycles);
             }
             var dataList = cycles.stream()
-                    .<ModFileInfo>mapMulti(Iterable::forEach)
-                    .<IModInfo>mapMulti((mf, c) -> mf.getMods().forEach(c))
-                    .map(IModInfo::getModId)
+                    .map(cycle -> cycle.stream()
+                            .map(IModInfo::getModId)
+                            .sorted()
+                            .collect(Collectors.joining(", ")))
                     .map(list -> ModLoadingIssue.error("fml.modloadingissue.cycle", list).withCause(e))
                     .toList();
             throw new ModLoadingException(dataList);

--- a/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
+++ b/loader/src/main/java/net/neoforged/fml/loading/moddiscovery/ModInfo.java
@@ -201,6 +201,11 @@ public class ModInfo implements IModInfo, IConfigurable {
         }
     }
 
+    @Override
+    public String toString() {
+        return modId + " (" + displayName + ") @ " + version;
+    }
+
     class ModVersion implements net.neoforged.neoforgespi.language.IModInfo.ModVersion {
         private IModInfo owner;
         private final String modId;

--- a/loader/src/test/java/net/neoforged/fml/loading/FMLLoaderTest.java
+++ b/loader/src/test/java/net/neoforged/fml/loading/FMLLoaderTest.java
@@ -396,6 +396,53 @@ class FMLLoaderTest extends LauncherTest {
         }
 
         @Test
+        void testDependencyCycle() throws Exception {
+            installation.setupProductionClient();
+            installation.buildModJar("mod_one.jar")
+                    .withModsToml(builder -> {
+                        builder.unlicensedJavaMod();
+                        builder.addMod("mod_one", "1.0");
+                        builder.customize(config -> {
+                            var dependency = Config.inMemory();
+                            dependency.set("modId", "mod_two");
+                            dependency.set("versionRange", "[1.0,)");
+                            dependency.set("ordering", "BEFORE");
+                            config.set(List.of("dependencies", "mod_one"), List.of(dependency));
+                        });
+                    })
+                    .build();
+            installation.buildModJar("mod_two.jar")
+                    .withModsToml(builder -> {
+                        builder.unlicensedJavaMod();
+                        builder.addMod("mod_two", "1.0");
+                        builder.customize(config -> {
+                            var dependency = Config.inMemory();
+                            dependency.set("modId", "mod_three");
+                            dependency.set("versionRange", "[1.0,)");
+                            dependency.set("ordering", "BEFORE");
+                            config.set(List.of("dependencies", "mod_two"), List.of(dependency));
+                        });
+                    })
+                    .build();
+            installation.buildModJar("mod_three.jar")
+                    .withModsToml(builder -> {
+                        builder.unlicensedJavaMod();
+                        builder.addMod("mod_three", "1.0");
+                        builder.customize(config -> {
+                            var dependency = Config.inMemory();
+                            dependency.set("modId", "mod_one");
+                            dependency.set("versionRange", "[1.0,)");
+                            dependency.set("ordering", "BEFORE");
+                            config.set(List.of("dependencies", "mod_three"), List.of(dependency));
+                        });
+                    })
+                    .build();
+
+            var e = assertThrows(ModLoadingException.class, () -> launchAndLoad("forgeclient"));
+            assertThat(getTranslatedIssues(e.getIssues())).containsOnly("ERROR: Detected a mod dependency cycle: mod_one, mod_three, mod_two");
+        }
+
+        @Test
         void testDependencyOverride() throws Exception {
             installation.setupProductionClient();
             installation.writeConfig("[dependencyOverrides]", "targetmod = [\"-depmod\", \"-incompatiblemod\"]");


### PR DESCRIPTION
This is a backport of 
* #427
(cherry picked from commit 66f884c67ece8556fc270c23ae0be54839b99b4b)